### PR TITLE
Introducing Seed Checker for #85

### DIFF
--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -34,11 +34,12 @@ _EXPECTED_RESULT_FILE_COUNTS = {
 
 
 def _get_sub_folders(folder):
-    sub_folders = [os.path.join(folder, sub_folder)
-                   for sub_folder in os.listdir(folder)]
-    return [sub_folder
-            for sub_folder in sub_folders
-            if os.path.isdir(sub_folder)]
+    sub_folders = [
+        os.path.join(folder, sub_folder) for sub_folder in os.listdir(folder)
+    ]
+    return [
+        sub_folder for sub_folder in sub_folders if os.path.isdir(sub_folder)
+    ]
 
 
 def _print_divider_bar():
@@ -80,12 +81,13 @@ def check_training_result_files(folder, ruleset, quiet, werror):
             print('System {}'.format(system))
             print('Benchmark {}'.format(benchmark))
 
-            # If the organization did submit results for this benchmark, the number
-            # of result files must be an exact number.
+            # If the organization did submit results for this benchmark, the
+            # number of result files must be an exact number.
             if len(result_files) != _EXPECTED_RESULT_FILE_COUNTS[benchmark]:
                 print('Expected {} runs, but detected {} runs.'.format(
                     _EXPECTED_RESULT_FILE_COUNTS[benchmark],
-                    len(result_files)))
+                    len(result_files),
+                ))
 
             errors_found = 0
             result_files.sort()
@@ -99,23 +101,31 @@ def check_training_result_files(folder, ruleset, quiet, werror):
                 print('Run {}'.format(run))
                 config_file = '{ruleset}/common.yaml'.format(
                     ruleset=ruleset,
-                    benchmark=benchmark)
+                    benchmark=benchmark,
+                )
                 checker = mlp_compliance.make_checker(
                     ruleset=ruleset,
                     quiet=quiet,
-                    werror=werror)
-                valid, _, _, _ = mlp_compliance.main(result_file, config_file, checker)
+                    werror=werror,
+                )
+                valid, _, _, _ = mlp_compliance.main(
+                    result_file,
+                    config_file,
+                    checker,
+                )
                 if not valid:
-                  errors_found += 1
+                    errors_found += 1
             if errors_found == 1:
-              print('WARNING: One file does not comply.')
-              print('WARNING: Allowing this failure under olympic scoring rules.')
+                print('WARNING: One file does not comply.')
+                print('WARNING: Allowing this failure under olympic scoring '
+                      'rules.')
             if errors_found > 1:
-              too_many_errors = True
+                too_many_errors = True
 
             _print_divider_bar()
     if too_many_errors:
-      raise Exception('Found too many errors in logging, see log above for details.')
+        raise Exception(
+            'Found too many errors in logging, see log above for details.')
 
 
 def check_training_package(folder, ruleset, quiet, werror):
@@ -134,16 +144,31 @@ def get_parser():
         description='Lint MLPerf submission packages.',
     )
 
-    parser.add_argument('folder', type=str,
-                    help='the folder for a submission package')
-    parser.add_argument('usage', type=str,
-                    help='the usage such as training, inference_edge, inference_server')
-    parser.add_argument('ruleset', type=str,
-                    help='the ruleset such as 0.6.0, 0.7.0')
-    parser.add_argument('--werror', action='store_true',
-                    help='Treat warnings as errors')
-    parser.add_argument('--quiet', action='store_true',
-                    help='Suppress warnings. Does nothing if --werror is set')
+    parser.add_argument(
+        'folder',
+        type=str,
+        help='the folder for a submission package',
+    )
+    parser.add_argument(
+        'usage',
+        type=str,
+        help='the usage such as training, inference_edge, inference_server',
+    )
+    parser.add_argument(
+        'ruleset',
+        type=str,
+        help='the ruleset such as 0.6.0, 0.7.0',
+    )
+    parser.add_argument(
+        '--werror',
+        action='store_true',
+        help='Treat warnings as errors',
+    )
+    parser.add_argument(
+        '--quiet',
+        action='store_true',
+        help='Suppress warnings. Does nothing if --werror is set',
+    )
 
     return parser
 

--- a/mlperf_logging/package_checker/seed_checker.py
+++ b/mlperf_logging/package_checker/seed_checker.py
@@ -1,0 +1,145 @@
+import warnings
+import os
+
+from ..compliance_checker import mlp_parser
+
+# What are source files?
+SOURCE_FILE_EXT = {
+    '.py', '.cc', '.cpp', '.cxx', '.c', '.h', '.hh', '.hpp', '.hxx', '.sh',
+    '.sub', '.cu', '.cuh'
+}
+
+
+def is_source_file(path):
+    """ Check if a file is considered as a "source file" by extensions.
+
+    The extensions that are considered as "source file" are listed in
+    SOURCE_FILE_EXT.
+
+    Args:
+        path: The absolute path, relative path or name to/of the file.
+    """
+    return os.path.splitext(path)[1].lower() in SOURCE_FILE_EXT
+
+
+def find_source_files_under(path):
+    """ Find all source files in all sub-directories under a directory.
+
+    Args:
+        path: The absolute or relative path to the directory under query.
+    """
+    source_files = []
+    for root, subdirs, files in os.walk(path):
+        for file_name in files:
+            if is_source_file(file_name):
+                source_files.append(os.path.join(root, file_name))
+    return source_files
+
+
+class SeedChecker:
+    """ Check if the seeds fit MLPerf submission requirements.
+    Current requirements are:
+    1. All seeds must be logged through mllog (if choose to log seeds). Any seed
+       logged via any other method will be disgarded.
+    2. All seeds, if choose to be logged, must be valid integer (convertible via
+       int()).
+    3. If any run log at lesat one seed, we expect all runs to log at least
+       one seed.
+    4. The set of seed(s) that one run logs must be completely different from
+       the set of seed(s) any other run logs.
+    Unsatisfying any of the above requirements results in check failure.
+
+    A warning is raised for the following situations:
+    1. Any run logs more than one seed.
+    2. No seed is logged. However, the source files contain the keyword whose
+       lowercase is "seed". What files are considered as source files are
+       defined in SOURCE_FILE_EXT and is_source_file().
+
+    """
+    def __init__(self, ruleset):
+        self._ruleset = ruleset
+
+    def _get_seed(self, result_file):
+        loglines, errors = mlp_parser.parse_file(
+            result_file,
+            ruleset=self._ruleset,
+        )
+        if len(errors) > 0:
+            raise ValueError('\n'.join(
+                ['Found parsing errors:'] +
+                ['{}\n  ^^  {}'.format(line, error)
+                 for line, error in errors] +
+                ['', 'Log lines had parsing errors.']))
+        return [
+            int(line.value['value']) for line in loglines if line.key == 'seed'
+        ]
+
+    def _assert_unique_seed_per_run(self, result_files):
+        no_logged_seed = True
+        error_messages = []
+        seed_to_result_file = {}
+        for result_file in result_files:
+            try:
+                seeds = self._get_seed(result_file)
+            except Exception as e:
+                error_messages.append("Error found when querying seeds from "
+                                      "{}: {}".format(result_file, e))
+                continue
+
+            if not no_logged_seed and len(seeds) == 0:
+                error_messages.append(
+                    "Result file {} logs no seed. However, other "
+                    "result files, including {}, already logs some "
+                    "seeds.".format(list(seed_to_result_file.keys())))
+            if no_logged_seed and len(seeds) > 0:
+                no_logged_seed = False
+            if len(seeds) > 1:
+                warnings.warn("Result file {} logs more than one "
+                              "seeds {}!".format(result_file, seeds))
+            for seed in seeds:
+                if seed in seed_to_result_file:
+                    error_messages.append(
+                        "Result file {} logs seed {}. However, result file {} "
+                        "already logs the same seed {}.".format(
+                            result_file,
+                            seed,
+                            seed_to_result_file[seed],
+                            seed,
+                        ))
+                else:
+                    seed_to_result_file[seed] = result_file
+
+        return no_logged_seed, error_messages
+
+    def _has_seed_keyword(self, source_file):
+        with open(source_file, 'r') as file_handle:
+            for line in file_handle.readlines():
+                if 'seed' in line.lower():
+                    return True
+        return False
+
+    def check_seeds(self, result_files, source_files):
+        """ Check the seeds for a specific benchmark submission.
+
+        Args:
+            result_files: An iterable contains paths to all the result files for
+                this benchmark.
+            source_files: An iterable contains paths to all the source files for
+                this benchmark.
+
+        """
+        no_logged_seed, error_messages = self._assert_unique_seed_per_run(
+            result_files)
+
+        if len(error_messages) > 0:
+            print("Seed checker failed and found the following "
+                  "errors:\n{}".format('\n'.join(error_messages)))
+            return False
+
+        if no_logged_seed:
+            for source_file in source_files:
+                if self._has_seed_keyword(source_file):
+                    warnings.warn(
+                        "Source file {} contains the keyword 'seed' but no "
+                        "seed value is logged!".format(source_file))
+        return True


### PR DESCRIPTION
Hi @xyhuang ,

Hope things are going well! Please review this PR for implementing seed checker for #85. 

In addition to the rules layout in #85, the following additional requirements are added to root out corner cases:

1. All seeds must be logged through mllog (if choose to log seeds). Any seed logged via any other method will be disgarded.
2. All seeds, if choose to be logged, must be valid integer (convertible via int()).
3. If any run log at lesat one seed, we expect all runs to log at least one seed.
4. The set of seed(s) that one run logs must be completely different from the set of seed(s) any other run logs.
