### PR TITLE
[package checker] add missing comma

### DIFF
--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -42,7 +42,7 @@ _ALLOWED_BENCHMARKS_V10 = [
     'minigo',
     'resnet',
     'ssd',
-    'rnnt'
+    'rnnt',
     'unet3d',
 ]
 


### PR DESCRIPTION
There is a missing comma in the `_ALLOWED_BENCHMARKS_V10` list, so `rnnt` and `unet3d` are merged into a single string.