### PR TITLE
WARNING -> ERROR if rcp checking fails in package checker.

### DIFF
--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -187,7 +187,7 @@ def check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass):
                 # Now go again through result files to do RCP checks
                 rcp_pass, rcp_msg = rcp_chk._check_directory(benchmark_folder, rcp_bypass)
                 if not rcp_pass:
-                    print('WARNING: RCP Test Failed: {}.'.format(rcp_msg))
+                    print('ERROR: RCP Test Failed: {}.'.format(rcp_msg))
                     too_many_errors = True
 
             _print_divider_bar()


### PR DESCRIPTION
`rcp_chk._check_directory` only return False when `rcp_bypass` is `False` and RCP checking actually failed. Thus, `WARNING` is not very accurate. 