### PR TITLE
[RCP checker] handle BERT-sepcific progress reporting

### DIFF
--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -74,7 +74,7 @@ def _print_divider_bar():
     print('------------------------------')
 
 
-def check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass):
+def check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass, bert_train_samples):
     """Checks all result files for compliance.
 
     Args:
@@ -181,7 +181,7 @@ def check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass):
 
             # Run RCP checker for 1.0.0
             if ruleset == '1.0.0' and division == 'closed' and benchmark != 'minigo':
-                rcp_chk = rcp_checker.make_checker(ruleset, verbose=False)
+                rcp_chk = rcp_checker.make_checker(ruleset, verbose=False, bert_train_samples=bert_train_samples)
                 rcp_chk._compute_rcp_stats()
 
                 # Now go again through result files to do RCP checks
@@ -218,14 +218,14 @@ def check_systems(folder, ruleset):
             'Found too many errors in system checking, see log above for details.')
 
 
-def check_training_package(folder, ruleset, quiet, werror, rcp_bypass):
+def check_training_package(folder, ruleset, quiet, werror, rcp_bypass, bert_train_samples):
     """Checks a training package for compliance.
 
     Args:
         folder: The folder for a submission package.
         ruleset: The ruleset such as 0.6.0, 0.7.0, or 1.0.0.
     """
-    check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass)
+    check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass, bert_train_samples)
     if ruleset == '1.0.0':
         check_systems(folder, ruleset)
 
@@ -265,6 +265,13 @@ def get_parser():
         action='store_true',
         help='Bypass failed RCP checks so that submission uploads'
     )
+    parser.add_argument(
+        '--bert_train_samples',
+        action='store_true',
+        help='If set, num samples used for training '
+             'bert benchmark is taken from train_samples, '
+             'istead of epoch_num',
+    )
     return parser
 
 
@@ -279,7 +286,7 @@ def main():
         print('Ruleset {} is not yet supported.'.format(args.ruleset))
         sys.exit(1)
 
-    check_training_package(args.folder, args.ruleset, args.quiet, args.werror, args.rcp_bypass)
+    check_training_package(args.folder, args.ruleset, args.quiet, args.werror, args.rcp_bypass, args.bert_train_samples)
 
 
 if __name__ == '__main__':

--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -74,7 +74,7 @@ def _print_divider_bar():
     print('------------------------------')
 
 
-def check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass, bert_train_samples):
+def check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass, rcp_bert_train_samples):
     """Checks all result files for compliance.
 
     Args:
@@ -181,7 +181,7 @@ def check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass, bert
 
             # Run RCP checker for 1.0.0
             if ruleset == '1.0.0' and division == 'closed' and benchmark != 'minigo':
-                rcp_chk = rcp_checker.make_checker(ruleset, verbose=False, bert_train_samples=bert_train_samples)
+                rcp_chk = rcp_checker.make_checker(ruleset, verbose=False, bert_train_samples=rcp_bert_train_samples)
                 rcp_chk._compute_rcp_stats()
 
                 # Now go again through result files to do RCP checks
@@ -218,14 +218,14 @@ def check_systems(folder, ruleset):
             'Found too many errors in system checking, see log above for details.')
 
 
-def check_training_package(folder, ruleset, quiet, werror, rcp_bypass, bert_train_samples):
+def check_training_package(folder, ruleset, quiet, werror, rcp_bypass, rcp_bert_train_samples):
     """Checks a training package for compliance.
 
     Args:
         folder: The folder for a submission package.
         ruleset: The ruleset such as 0.6.0, 0.7.0, or 1.0.0.
     """
-    check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass, bert_train_samples)
+    check_training_result_files(folder, ruleset, quiet, werror, rcp_bypass, rcp_bert_train_samples)
     if ruleset == '1.0.0':
         check_systems(folder, ruleset)
 
@@ -266,7 +266,7 @@ def get_parser():
         help='Bypass failed RCP checks so that submission uploads'
     )
     parser.add_argument(
-        '--bert_train_samples',
+        '--rcp_bert_train_samples',
         action='store_true',
         help='If set, num samples used for training '
              'bert benchmark is taken from train_samples, '
@@ -286,7 +286,7 @@ def main():
         print('Ruleset {} is not yet supported.'.format(args.ruleset))
         sys.exit(1)
 
-    check_training_package(args.folder, args.ruleset, args.quiet, args.werror, args.rcp_bypass, args.bert_train_samples)
+    check_training_package(args.folder, args.ruleset, args.quiet, args.werror, args.rcp_bypass, args.rcp_bert_train_samples)
 
 
 if __name__ == '__main__':

--- a/mlperf_logging/rcp_checker/__main__.py
+++ b/mlperf_logging/rcp_checker/__main__.py
@@ -6,7 +6,7 @@ parser = rcp_checker.get_parser()
 args = parser.parse_args()
 
 # Results summarizer makes these 3 calls to invoke RCP test
-checker = rcp_checker.make_checker(args.rcp_version, args.verbose)
+checker = rcp_checker.make_checker(args.rcp_version, args.verbose, args.bert_train_samples)
 checker._compute_rcp_stats()
 test, msg = checker._check_directory(args.dir)
 

--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -29,8 +29,9 @@ TOKEN = ':::MLLOG '
 
 def get_submission_epochs(result_files, benchmark):
     '''
-    Extract convergence epochs from a list of submission files
-    Returns the batch size and the list of epochs to converge
+    Extract convergence epochs (or train_samples for BERT)
+    from a list of submission files
+    Returns the batch size and the list of epochs (or samples) to converge
     -1 means run did not converge. Return None if > 1 files
     fail to converge
     '''
@@ -50,13 +51,16 @@ def get_submission_epochs(result_files, benchmark):
                         # Do we need to make sure global_batch_size is the same
                         # in all files? If so, this is obviously a bad submission
                         bs = json.loads(str)["value"]
-                    if "eval_accuracy" in str:
+                    if benchmark != 'bert' and "eval_accuracy" in str:
                         eval_accuracy_str = str
+                        conv_epoch = json.loads(eval_accuracy_str)["metadata"]["epoch_num"]
+                    if benchmark == 'bert' and "train_samples" in str:
+                        eval_accuracy_str = str
+                        conv_epoch = json.loads(eval_accuracy_str)["value"]
                     if "run_stop" in str:
                         # Epochs to converge is the the last epochs value on
                         # eval_accuracy line before run_stop
                         conv_result = json.loads(str)["metadata"]["status"]
-                        conv_epoch = json.loads(eval_accuracy_str)["metadata"]["epoch_num"]
                         if conv_result == "success":
                             subm_epochs.append(conv_epoch)
                         else:

--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -27,7 +27,7 @@ submission_runs = {
 TOKEN = ':::MLLOG '
 
 
-def get_submission_epochs(result_files, benchmark):
+def get_submission_epochs(result_files, benchmark, bert_train_samples):
     '''
     Extract convergence epochs (or train_samples for BERT)
     from a list of submission files
@@ -38,6 +38,7 @@ def get_submission_epochs(result_files, benchmark):
     not_converged = 0
     subm_epochs = []
     bs = -1
+    use_train_samples = benchmark == 'bert' and bert_train_samples
     for result_file in result_files:
         with open(result_file, 'r', encoding='latin-1') as f:
             file_contents = f.readlines()
@@ -51,10 +52,10 @@ def get_submission_epochs(result_files, benchmark):
                         # Do we need to make sure global_batch_size is the same
                         # in all files? If so, this is obviously a bad submission
                         bs = json.loads(str)["value"]
-                    if benchmark != 'bert' and "eval_accuracy" in str:
+                    if not use_train_samples and "eval_accuracy" in str:
                         eval_accuracy_str = str
                         conv_epoch = json.loads(eval_accuracy_str)["metadata"]["epoch_num"]
-                    if benchmark == 'bert' and "train_samples" in str:
+                    if use_train_samples and "train_samples" in str:
                         eval_accuracy_str = str
                         conv_epoch = json.loads(eval_accuracy_str)["value"]
                     if "run_stop" in str:
@@ -73,13 +74,14 @@ def get_submission_epochs(result_files, benchmark):
 
 class RCP_Checker:
 
-    def __init__(self, ruleset, verbose):
+    def __init__(self, ruleset, verbose, bert_train_samples):
         if ruleset != '1.0.0':
             raise Exception('RCP Checker only supported in 1.0.0')
         self.alpha = 0.05
         self.tolerance = 0.0001
         self.verbose = verbose
         self.rcp_data = {}
+        self.bert_train_samples = bert_train_samples
         for benchmark in submission_runs.keys():
             raw_rcp_data = self._consume_json_file(ruleset, benchmark)
             processed_rcp_data = self._process_raw_rcp_data(raw_rcp_data)
@@ -299,7 +301,7 @@ class RCP_Checker:
         pattern = '{folder}/result_*.txt'.format(folder=dir)
         benchmark = os.path.split(dir)[1]
         result_files = glob.glob(pattern, recursive=True)
-        bs, subm_epochs = get_submission_epochs(result_files, benchmark)
+        bs, subm_epochs = get_submission_epochs(result_files, benchmark, self.bert_train_samples)
 
         if bs == -1:
             return False, 'Could not detect global_batch_size'
@@ -354,12 +356,16 @@ def get_parser():
     parser.add_argument('--rcp_version', type=str, default='1.0.0',
                     help='what version of rules to check the log against')
     parser.add_argument('--verbose', action='store_true')
+    parser.add_argument('--bert_train_samples', action='store_true',
+                    help='If set, num samples used for training '
+                         'bert benchmark is taken from train_samples, '
+                         'istead of epoch_num')
 
     return parser
 
 
-def make_checker(ruleset, verbose=False):
-  return RCP_Checker(ruleset, verbose)
+def make_checker(ruleset, verbose=False, bert_train_samples=False):
+  return RCP_Checker(ruleset, verbose, bert_train_samples)
 
 
 def main(checker, dir):


### PR DESCRIPTION
Colleagues working on BERT noticed, that BERT is not reporting `num_epochs`, so they propose to use `train_samples` in RCP checker instead.
Let's discuss it on the meeting today.