### PR TITLE
[recommendation] round floating point epoch number

### DIFF
--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -55,6 +55,7 @@ def get_submission_epochs(result_files, benchmark, bert_train_samples):
                     if not use_train_samples and "eval_accuracy" in str:
                         eval_accuracy_str = str
                         conv_epoch = json.loads(eval_accuracy_str)["metadata"]["epoch_num"]
+                        conv_epoch = round(conv_epoch, 3)
                     if use_train_samples and "train_samples" in str:
                         eval_accuracy_str = str
                         conv_epoch = json.loads(eval_accuracy_str)["value"]


### PR DESCRIPTION
DLRM benchmark is very stable, and after dropping the fastest and the slowest result, all results are the same. As result, RCPs require a perfect match in submission. It is problematic, because epochs are reported as a floating point, and comparing floating-point numbers is error-prone.

To mitigate this issue, DLRM RCPs are rounded. However, rounding of submission epochs is missing. As result, the RCP checker rejects legal submissions.

This MR adds the missing part. Because other benchmarks report epochs as integers, this change has no impact on them.