### PR TITLE
[Compliance][HPC][DeepCam] Replace the num_workers rule with number_of_nodes and accelerators_per_node.

### DIFF
--- a/mlperf_logging/compliance_checker/hpc_1.0.0/closed_deepcam.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/closed_deepcam.yaml
@@ -15,7 +15,12 @@
     CHECK: " v['value'] > 0"
     
 - KEY:
-    NAME:  num_workers
+    NAME:  number_of_nodes
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] > 0"
+
+- KEY:
+    NAME:  accelerators_per_node
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] > 0"
 


### PR DESCRIPTION
@azrael417 please review this PR; in addition, could you update [HPC's DeepCam's README](https://github.com/mlcommons/hpc/tree/main/deepcam#hyperparameters) accordingly so that other submitter would know?

Thanks!

=======================================
Explanation:
In [DeepCam](https://github.com/mlcommons/hpc/tree/main/deepcam), `num_workers` is deprecated and will be replaced by `num_of_nodes` and `accelerators_per_node`. The purpose of this is to support weak scaling benchmarking in HPC: https://github.com/mlcommons/training_policies/blob/master/hpc_training_rules.adoc#62-weak-scaling-throughput