### PR TITLE
Update oc20 RCPs for MLPerf HPC v1

### DIFF
--- a/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_oc20.json
+++ b/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_oc20.json
@@ -1,5 +1,5 @@
 {
-    "oc20_ref_64": {
+    "oc20_ref_256": {
         "Benchmark": "oc20",
         "BS": 256,
         "Epochs to converge": [ 20, 18, 20, 20, 22, 18, 19, 19, 21, 21 ],

--- a/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_oc20.json
+++ b/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_oc20.json
@@ -11,5 +11,18 @@
             "opt_learning_rate_decay_boundary_steps": [ 125008, 187512, 250016 ],
             "opt_learning_rate_decay_factor": 0.1
         }
+    },
+    "oc20_ref_1024": {
+        "Benchmark": "oc20",
+        "BS": 1024,
+        "Epochs to converge": [ 23, 25, 22, 25, 25, 25, 25, 24, 23, 25 ],
+        "Hyperparams": {
+            "global_batch_size": 1024,
+            "opt_base_learning_rate": 0.0012,
+            "opt_learning_rate_warmup_steps": 7816,
+            "opt_learning_rate_warmup_factor": 0.2,
+            "opt_learning_rate_decay_boundary_steps": [ 31264, 46896 ],
+            "opt_learning_rate_decay_factor": 0.1
+        }
     }
 }

--- a/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_oc20.json
+++ b/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_oc20.json
@@ -2,7 +2,7 @@
     "oc20_ref_64": {
         "Benchmark": "oc20",
         "BS": 256,
-        "Epochs to converge": [ 19, 19, 19, 19, 19, 19, 19, 19, 19, 19 ],
+        "Epochs to converge": [ 20, 18, 20, 20, 22, 18, 19, 19, 21, 21 ],
         "Hyperparams": {
             "global_batch_size": 256,
             "opt_base_learning_rate": 0.0004,


### PR DESCRIPTION
This PR is needed for the upcoming MLPerf HPC v1 submission deadine (Oct 8).

Previous RCP was renamed to `oc20_ref_256` to reflect the actual batch size used (not sure how I messed that up).

I reran the RCP at batch size 256 after fixing a seeding issue so that each run used a unique seed.

I have also added a new RCP for batch size 1024.