### PR TITLE
[HPC][Compliance|Result Summarizer] Allow accelerators_per_node to be 0 on pure-CPU systems.

### DIFF
--- a/mlperf_logging/compliance_checker/hpc_1.0.0/closed_common.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/closed_common.yaml
@@ -12,3 +12,13 @@
 - KEY:
     NAME:  gradient_accumulation_frequency
     CHECK: " v['value'] > 0 "
+
+- KEY:
+    NAME:  number_of_nodes
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] > 0"
+
+- KEY:
+    NAME:  accelerators_per_node
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] >= 0"

--- a/mlperf_logging/compliance_checker/hpc_1.0.0/closed_deepcam.yaml
+++ b/mlperf_logging/compliance_checker/hpc_1.0.0/closed_deepcam.yaml
@@ -15,16 +15,6 @@
     CHECK: " v['value'] > 0"
     
 - KEY:
-    NAME:  number_of_nodes
-    REQ:   EXACTLY_ONE
-    CHECK: " v['value'] > 0"
-
-- KEY:
-    NAME:  accelerators_per_node
-    REQ:   EXACTLY_ONE
-    CHECK: " v['value'] > 0"
-
-- KEY:
     NAME:  batchnorm_group_size
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] > 0"

--- a/mlperf_logging/result_summarizer/result_summarizer.py
+++ b/mlperf_logging/result_summarizer/result_summarizer.py
@@ -162,7 +162,7 @@ def _query_instance_scale(loglines):
         raise ValueError('number_of_nodes not recorded')
     if accelerators_per_node is None:
         raise ValueError('accelerators_per_node not recorded')
-    return int(number_of_nodes) * int(accelerators_per_node)
+    return int(number_of_nodes) * max(int(accelerators_per_node), 1)
 
 
 def _compute_olympic_average(scores, dropped_scores, max_dropped_scores):


### PR DESCRIPTION
This PR address #165 . If `accelerators_per_node` contains 0 in the logs, we assume that this is a pure-CPU system, and the instance scale is the `number_of_nodes`.

This PR also move the `accelerators_per_node` and `number_of_nodes` compliance check to `hpc_1.0.0/closed_common.yaml` to check those tags for all hpc benchmarks.