### PR TITLE
Update oc20 RCPs

### DIFF
--- a/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_oc20.json
+++ b/mlperf_logging/rcp_checker/hpc_1.0.0/rcps_oc20.json
@@ -24,5 +24,18 @@
             "opt_learning_rate_decay_boundary_steps": [ 31264, 46896 ],
             "opt_learning_rate_decay_factor": 0.1
         }
+    },
+    "oc20_ref_2048": {
+        "Benchmark": "oc20",
+        "BS": 2048,
+        "Epochs to converge": [ 33, 32, 33, 33, 33, 34, 33, 33, 30, 33 ],
+        "Hyperparams": {
+            "global_batch_size": 2048,
+            "opt_base_learning_rate": 0.0016,
+            "opt_learning_rate_warmup_steps": 3908,
+            "opt_learning_rate_warmup_factor": 0.2,
+            "opt_learning_rate_decay_boundary_steps": [ 23448, 31264 ],
+            "opt_learning_rate_decay_factor": 0.1
+        }
     }
 }

--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -27,7 +27,7 @@ submission_runs = {
     "hpc": {
         'cosmoflow': 10,
         'deepcam': 5,
-        #'oc20': 10,
+        'oc20': 5,
     }
 }
 


### PR DESCRIPTION
This PR enables the oc20 benchmark in the RCP checker.

It also adds a new oc20 RCP for batch size 2048.

Thank you,
Steve