### PR TITLE
Logging lib -- checker logging improvements (#180)

### DIFF
--- a/mlperf_logging/compliance_checker/__main__.py
+++ b/mlperf_logging/compliance_checker/__main__.py
@@ -1,10 +1,16 @@
 import sys
+import logging
 
 from . import mlp_compliance
 
-
 parser = mlp_compliance.get_parser()
 args = parser.parse_args()
+
+logging.basicConfig(filename=args.log_output, encoding='utf-8', level=logging.INFO)
+logging.getLogger().addHandler(logging.StreamHandler())
+formatter = logging.Formatter("%(levelname)s - %(message)s")
+logging.getLogger().handlers[0].setFormatter(formatter)
+logging.getLogger().handlers[1].setFormatter(formatter)
 
 config_file = args.config or f'{args.usage}_{args.ruleset}/common.yaml'
 
@@ -17,12 +23,10 @@ checker = mlp_compliance.make_checker(
 
 valid, system_id, benchmark, result = mlp_compliance.main(args.filename, config_file, checker)
 
-print(valid)
-print(system_id)
-print(benchmark)
-print(result)
-
 if not valid:
+    logging.error('FAILED')
+    print('** Logging output also at', args.log_output)
     sys.exit(1)
 else:
-    print('SUCCESS')
+    print('** Logging output also at', args.log_output)
+    logging.info('SUCCESS')

--- a/mlperf_logging/package_checker/seed_checker.py
+++ b/mlperf_logging/package_checker/seed_checker.py
@@ -1,5 +1,6 @@
 import warnings
 import os
+import logging
 
 from ..compliance_checker import mlp_parser
 
@@ -8,6 +9,10 @@ SOURCE_FILE_EXT = {
     '.py', '.cc', '.cpp', '.cxx', '.c', '.h', '.hh', '.hpp', '.hxx', '.sh',
     '.sub', '.cu', '.cuh'
 }
+
+
+def _print_divider_bar():
+    logging.info('------------------------------')
 
 
 def is_source_file(path):
@@ -137,12 +142,15 @@ class SeedChecker:
                 this benchmark.
 
         """
+        _print_divider_bar()
+        logging.info(" Running Seed Checker")
         no_logged_seed, error_messages = self._assert_unique_seed_per_run(
             result_files)
 
         if len(error_messages) > 0:
-            print("Seed checker failed and found the following "
-                  "errors:\n{}".format('\n'.join(error_messages)))
+            logging.error(" Seed checker failed and found the following errors %s: ", join(error_messages))
+            #print("Seed checker failed and found the following "
+            #      "errors:\n{}".format('\n'.join(error_messages)))
             return False
 
         if no_logged_seed:

--- a/mlperf_logging/rcp_checker/__main__.py
+++ b/mlperf_logging/rcp_checker/__main__.py
@@ -1,9 +1,16 @@
 import sys
+import logging
 
 from . import rcp_checker
 
 parser = rcp_checker.get_parser()
 args = parser.parse_args()
+
+logging.basicConfig(filename=args.log_output, encoding='utf-8', level=logging.INFO)
+logging.getLogger().addHandler(logging.StreamHandler())
+formatter = logging.Formatter("%(levelname)s - %(message)s")
+logging.getLogger().handlers[0].setFormatter(formatter)
+logging.getLogger().handlers[1].setFormatter(formatter)
 
 # Results summarizer makes these 3 calls to invoke RCP test
 checker = rcp_checker.make_checker(args.rcp_usage, args.rcp_version, args.verbose, args.bert_train_samples)
@@ -11,7 +18,10 @@ checker._compute_rcp_stats()
 test, msg = checker._check_directory(args.dir)
 
 if test:
-    print(msg, ",RCP test passed")
+    logging.info('%s, RCP test PASSED', msg)
+    print('** Logging output also at', args.log_output)
 else:
-    print(msg, ",RCP test failed")
+    logging.error('%s, RCP test FAILED, consider adding --rcp_bypass in when running the package_checker if the RCP is NOT missing', msg)
+    print('** Logging output also at', args.log_output)
     sys.exit(1)
+

--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -5,6 +5,7 @@ RCP checker: Verifies convergence points of submissions by comparing them agains
 import argparse
 import glob
 import json
+import logging
 import os
 import numpy as np
 import re
@@ -32,6 +33,9 @@ submission_runs = {
 }
 
 TOKEN = ':::MLLOG '
+
+def _print_divider_bar():
+    logging.info('------------------------------')
 
 def _detect_eval_error(file_contents):
     for line in file_contents:
@@ -159,6 +163,7 @@ class RCP_Checker:
                               record_contents['RCP Stdev'],
                               len(epoch_list)-samples_rejected*2)
             record_contents['Max Speedup'] = record_contents['RCP Mean'] / min_epochs
+            # TODO emizan: Remove verbose if 1.1 round goes well w.r.to logs
             if self.verbose:
                 print(record, record_contents, "\n")
 
@@ -288,9 +293,10 @@ class RCP_Checker:
                          'RCP Mean': mean,
                          'RCP Stdev': stdev,
                          'Max Speedup': mean / min_epochs}
-        if self.verbose:
-            print(low_rcp, high_rcp)
-            print(interp_record)
+        logging.info(" Creating interpolation record")
+        logging.info(" Low RCP: %s", low_rcp)
+        logging.info(" High RCP: %s", high_rcp)
+        logging.info(" Intepolation record: %s", interp_record)
         self.rcp_data[interp_record_name] = interp_record
 
 
@@ -300,14 +306,12 @@ class RCP_Checker:
         samples_rejected = 4 if rcp_record["Benchmark"] == 'unet3d' else 1
         mean_subm_epochs = np.mean(subm_epochs[samples_rejected:len(subm_epochs)-samples_rejected])
         if mean_subm_epochs >= (rcp_record["RCP Mean"] / rcp_record["Max Speedup"]):
-            if self.verbose:
-                print("Found RCP record:\n",rcp_record)
-                print("\nSubm Mean epochs:", mean_subm_epochs)
+            logging.info(" RCP Record: %s", rcp_record)
+            logging.info(" Submission mean epochs: %.4f", mean_subm_epochs)
             return(True)
         else:
-            if self.verbose:
-                print("Found RCP record:\n",rcp_record)
-                print("\nSubm Mean epochs:", mean_subm_epochs)
+            logging.info(" RCP Record: %s", rcp_record)
+            logging.info(" Submission mean epochs: %.4f", mean_subm_epochs)
             return(False)
 
 
@@ -326,6 +330,9 @@ class RCP_Checker:
         - (False) Fail / RCP interpolated
         - (False) Missing RCP / Submit missing RCP
         '''
+        _print_divider_bar()
+        logging.info(" Running RCP Checker")
+        _print_divider_bar()
         dir = dir.rstrip("/")
         pattern = '{folder}/result_*.txt'.format(folder=dir)
         benchmark = os.path.split(dir)[1]
@@ -368,7 +375,7 @@ class RCP_Checker:
         if rcp_bypass and not rcp_check:
             if rcp_msg == 'RCP found' or rcp_msg == 'RCP Interpolation':
                 rcp_msg  = rcp_msg + ' passed using rcp_bypass'
-                print('RCP test failed but allowed to proceed with RCP bypass')
+                logging.warning(' RCP test failed but allowed to proceed with RCP bypass')
                 rcp_check = True
 
         return rcp_check, rcp_msg
@@ -385,14 +392,14 @@ def get_parser():
     parser.add_argument('--rcp_usage', type=str, default='training',
                     choices=['training', 'hpc'],
                     help='what WG does the benchmark come from to check the log against')
-    parser.add_argument('--rcp_version', type=str, default='1.0.0',
+    parser.add_argument('--rcp_version', type=str, default='1.1.0',
                     help='what version of rules to check the log against')
     parser.add_argument('--verbose', action='store_true')
     parser.add_argument('--bert_train_samples', action='store_true',
-                    help='If set, num samples used for training '
-                         'bert benchmark is taken from train_samples, '
-                         'istead of epoch_num')
-
+                    help='If set, num samples used for training bert benchmark'
+                         'is taken from train_samples, instead of epoch_num')
+    parser.add_argument('--log_output', type=str, default='rcp_checker.log',
+                    help='where to store RCP checker output log')
     return parser
 
 

--- a/mlperf_logging/system_desc_checker/system_desc_checker.py
+++ b/mlperf_logging/system_desc_checker/system_desc_checker.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import argparse
 import json
+import logging
 import sys
 
 from ..compliance_checker.mlp_compliance import usage_choices, rule_choices
@@ -114,12 +115,9 @@ def check_system_desc(json_file, usage, ruleset):
     ])
 
     if not valid:
-        print("FAILURE: {}".format(", ".join(invalid_reasons)))
+        logging.error('  System description checker failed for %s : %s', system_name, invalid_reasons)
     else:
-        print("SUCCESS")
-
-    print("Table CSV prefix: {}".format(table_csv_prefix))
-    print("Table CSV postfix: {}".format(table_csv_postfix))
+        logging.info('  System description checker passed for %s', system_name)
 
     return valid, system_name, table_csv_prefix, table_csv_postfix
 
@@ -140,7 +138,8 @@ def get_parser():
                     help='Treat warnings as errors')
     parser.add_argument('--quiet', action='store_true',
                     help='Suppress warnings. Does nothing if --werror is set')
-
+    parser.add_argument('--log_output', type=str, default='system_desc_checker.log',
+                    help='where to store system description checker output log')
     return parser
 
 
@@ -148,7 +147,14 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
+    logging.basicConfig(filename=args.log_output, encoding='utf-8', level=logging.INFO)
+    logging.getLogger().addHandler(logging.StreamHandler())
+    formatter = logging.Formatter("%(levelname)s - %(message)s")
+    logging.getLogger().handlers[0].setFormatter(formatter)
+    logging.getLogger().handlers[1].setFormatter(formatter)
+
     check_system_desc(args.filename, args.usage, args.ruleset)
+    print('** Logging output also at', args.log_output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Use the logging library instead of print(...) to display progress,
warnings, and errors
- Replaced almost all print(...) statements in the package, compliance,
and rcp checkers
- log outputs go to stdout and also to package_checker.log,
compliance_checker.log, rcp_checker.log, depending on what you run.
The lof iles can be changed from the command line.
- Added additional info to log outputs
- Removed exceptions/assertions at the end of the checkers when we find errors