### PR TITLE
fixed oc20 benchmark count to 5

### DIFF
--- a/mlperf_logging/benchmark_meta.py
+++ b/mlperf_logging/benchmark_meta.py
@@ -15,9 +15,9 @@ _ALL_RESULT_FILE_COUNTS = {
     },
     
     'hpc' : {
-    'deepcam': 5,
+        'deepcam': 5,
         'cosmoflow': 10,
-        'oc20': 10
+        'oc20': 5
     }
 }
 


### PR DESCRIPTION
The oc20 benchmark requires 5 runs, as listed here: https://github.com/mlcommons/training_policies/blob/master/hpc_training_rules.adoc#7-benchmark-results

This fixes the value in benchmark_meta.py