### PR TITLE
Fix typo in seed checker error logging

### DIFF
--- a/mlperf_logging/package_checker/seed_checker.py
+++ b/mlperf_logging/package_checker/seed_checker.py
@@ -148,7 +148,7 @@ class SeedChecker:
             result_files)
 
         if len(error_messages) > 0:
-            logging.error(" Seed checker failed and found the following errors %s: ", join(error_messages))
+            logging.error(" Seed checker failed and found the following errors: %s", '\n'.join(error_messages))
             #print("Seed checker failed and found the following "
             #      "errors:\n{}".format('\n'.join(error_messages)))
             return False


### PR DESCRIPTION
The seed checker error check has a typo in the logging.error call. The
join function is not defined, and should probably be changed to the
string join method. I used '\n' as the delimiter as it seems to be used
elsewhere as well.