### PR TITLE
[SSD] updated v2.0 RCPs with platform info

### DIFF
--- a/mlperf_logging/rcp_checker/training_2.0.0/rcps_ssd.json
+++ b/mlperf_logging/rcp_checker/training_2.0.0/rcps_ssd.json
@@ -5,7 +5,7 @@
     "Benchmark": "ssd",
     "Creator": "NVIDIA",
     "When": "Reference RCPs before v2.0",
-    "Platform": "TBD",
+    "Platform": "1xDGX-A100",
     "BS": 256,
     "Hyperparams": {
       "opt_base_learning_rate": 0.0001,
@@ -23,7 +23,7 @@
     "Benchmark": "ssd",
     "Creator": "NVIDIA",
     "When": "Reference RCPs before v2.0",
-    "Platform": "TBD",
+    "Platform": "8xDGX-A100",
     "BS": 512,
     "Hyperparams": {
       "opt_base_learning_rate": 0.0001,
@@ -41,7 +41,7 @@
     "Benchmark": "ssd",
     "Creator": "NVIDIA",
     "When": "Reference RCPs before v2.0",
-    "Platform": "TBD",
+    "Platform": "16xDGX-A100",
     "BS": 4096,
     "Hyperparams": {
       "opt_base_learning_rate": 0.0001,


### PR DESCRIPTION
The pull requests adds platform information to the SSD RCPs.
This change was requested by @emizan76  [here](https://github.com/mlcommons/logging/pull/209), and by Intel through email.