### PR TITLE
Spedify package version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setuptools.setup(
     license='Apache 2.0',
     include_package_data=True,
     install_requires=[
-        'pandas', 'pyyaml', 'numpy', 'scipy'
+        'pandas>=1.3.3', 'pyyaml>=5.4.1', 'numpy>=1.17.3', 'scipy>=1.4.1'
     ],
 )


### PR DESCRIPTION
Encounter an issue that pandas being installed is not capable with numpy, turns out it's because we always grab the latest pandas, and if there's an old verion numpy being install already then pip fails to fix it.

```
Traceback (most recent call last):
  File "./ml_perf/train_loop.py", line 23, in <module>
    import tensorflow as tf
  File "/usr/local/lib/python3.8/dist-packages/tensorflow/__init__.py", line 101, in <module>
    from tensorflow_core import *
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_core/__init__.py", line 36, in <module>
    from tensorflow._api.v1 import compat
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_core/_api/v1/compat/__init__.py", line 23, in <module>
    from tensorflow._api.v1.compat import v1
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_core/_api/v1/compat/v1/__init__.py", line 673, in <module>
    from tensorflow_estimator.python.estimator.api._v1 import estimator
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_estimator/__init__.py", line 10, in <module>
    from tensorflow_estimator._api.v1 import estimator
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_estimator/_api/v1/estimator/__init__.py", line 12, in <module>
    from tensorflow_estimator._api.v1.estimator import inputs
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_estimator/_api/v1/estimator/inputs/__init__.py", line 10, in <module>
    from tensorflow_estimator.python.estimator.inputs.numpy_io import numpy_input_fn
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_estimator/python/estimator/inputs/numpy_io.py", line 26, in <module>
    from tensorflow_estimator.python.estimator.inputs.queues import feeding_functions
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_estimator/python/estimator/inputs/queues/feeding_functions.py", line 40, in <module>
    import pandas as pd
  File "/usr/local/lib/python3.8/dist-packages/pandas/__init__.py", line 22, in <module>
    from pandas.compat import is_numpy_dev as _is_numpy_dev
  File "/usr/local/lib/python3.8/dist-packages/pandas/compat/__init__.py", line 14, in <module>
    from pandas._typing import F
  File "/usr/local/lib/python3.8/dist-packages/pandas/_typing.py", line 120, in <module>
    np.random.BitGenerator,
AttributeError: module 'numpy.random' has no attribute 'BitGenerator'
```