### PR TITLE
Lower pandas version constrain to work with py36

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setuptools.setup(
     license='Apache 2.0',
     include_package_data=True,
     install_requires=[
-        'pandas>=1.3.3', 'pyyaml>=5.4.1', 'numpy>=1.17.3', 'scipy>=1.4.1'
+        'pandas>=1.0', 'pyyaml>=5.4.1', 'numpy>=1.17.3', 'scipy>=1.4.1'
     ],
 )


### PR DESCRIPTION
pandas 1.3 requires py38 which could be [too high](https://github.com/mlcommons/logging/commit/f6d428f6f3a35bffb04b0c3a7d0ea08f2264abbb#commitcomment-72311614) , lower it so it should work for py36 now.

Tested locally py36 can use up to 1.1.5. Other packages should be fine too.