### PR TITLE
[MRCNN] allow lr 0.01 for when gbs < 16

### DIFF
--- a/mlperf_logging/compliance_checker/training_2.0.0/closed_maskrcnn.yaml
+++ b/mlperf_logging/compliance_checker/training_2.0.0/closed_maskrcnn.yaml
@@ -1,7 +1,8 @@
 - BEGIN:
     CODE: >
         s.update({
-            'initialized_tensors': []
+            'initialized_tensors': [],
+            'global_batch_size': None,
         })
 - KEY:
     NAME: weights_initialization
@@ -40,11 +41,12 @@
     NAME:  global_batch_size
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] > 0"
+    POST: " s['global_batch_size'] = v['value'] "
 
 - KEY:
     NAME:  opt_base_learning_rate
     REQ:   EXACTLY_ONE
-    CHECK: " is_integer(v['value'] / 0.02) "
+    CHECK: " is_integer(v['value'] / 0.02) or ( s['global_batch_size'] < 16 and is_integer(0.02 / v['value']) )"
 
 - KEY:
     NAME:  opt_learning_rate_warmup_steps


### PR DESCRIPTION
Together with this [PR](https://github.com/mlcommons/training_policies/compare/master...ShriyaPalsamudram:shriya-mrcnn-bugfix) to change the training policy for small batch size for mrcnn 