### PR TITLE
Fix closed_bert.yaml to be compliant with logging constants

### DIFF
--- a/mlperf_logging/compliance_checker/training_2.1.0/closed_bert.yaml
+++ b/mlperf_logging/compliance_checker/training_2.1.0/closed_bert.yaml
@@ -424,7 +424,7 @@
     REQ:   EXACTLY_ONE
 
 - KEY:
-    NAME:  opt_epsilon
+    NAME:  opt_lamb_epsilon
     REQ:   EXACTLY_ONE
 
 - KEY:


### PR DESCRIPTION
Should be compliant with constant in mlperf_logging/mllog/constatnts https://github.com/mlcommons/logging/blob/master/mlperf_logging/mllog/constants.py#L119