### PR TITLE
[RCP] Add previously unmerged Training 2.0 RCPs

### DIFF
--- a/mlperf_logging/rcp_checker/training_2.0.0/rcps_bert.json
+++ b/mlperf_logging/rcp_checker/training_2.0.0/rcps_bert.json
@@ -275,5 +275,28 @@
     "Epochs to converge": [
       4442880, 4592640, 4642560, 4842240, 4742400, 4592640, 4642560, 4692480, 4942080, 4542720,
       4592640, 4093440, 4442880, 4792320, 4642560, 4592640, 4592640, 4892160, 4742400, 4592640]
-  }
+  },
+ 
+  "bert_ref_16384":
+  {
+    "Benchmark": "bert",
+    "Creator": "NVIDIA",
+    "When": "At 2.0 submission",
+    "Platform": "TPU-v3-128",
+    "BS": 16384,
+    "Hyperparams": {
+        "opt_base_learning_rate": 0.0033,
+        "opt_epsilon": 1e-6,
+        "opt_learning_rate_training_steps": 600,
+        "num_warmup_steps": 290,
+        "start_warmup_step": -100,
+        "opt_lamb_beta_1": 0.75,
+        "opt_lamb_beta_2": 0.9,
+        "opt_lamb_weight_decay_rate": 0.0166629,
+        "gradient_accumulation_steps": 32
+    },
+    "Epochs to converge": [
+      5619712, 5770240, 5720064, 5419008, 5519360, 5569536, 5218304, 5469184, 5419008, 5218304,
+      5669888, 5669888, 5519360, 5569536, 5368832, 5469184, 5569536, 5469184, 5368832, 5469184]  
+    }
 }

--- a/mlperf_logging/rcp_checker/training_2.0.0/rcps_maskrcnn.json
+++ b/mlperf_logging/rcp_checker/training_2.0.0/rcps_maskrcnn.json
@@ -1,5 +1,23 @@
 {
 
+  "maskrcnn_ref_8":
+  {
+    "Benchmark": "maskrcnn",
+    "Creator": "NVIDIA",
+    "When": "Prior to 2.0 submission",
+    "Platform": "TBD",
+    "BS": 8,
+    "Hyperparams": {
+      "opt_learning_decay_steps": [144000, 192000],
+      "opt_base_learning_rate": 0.01,
+      "num_image_candidates": 1000,
+      "opt_learning_rate_warmup_factor": 0.00002,
+      "opt_learning_rate_warmup_steps": 500
+    },
+    "Epochs to converge": [
+       13, 13, 12, 13, 13, 13, 13, 12, 13, 12]
+  },
+
   "maskrcnn_ref_48":
   {
     "Benchmark": "maskrcnn",

--- a/mlperf_logging/rcp_checker/training_2.0.0/rcps_resnet.json
+++ b/mlperf_logging/rcp_checker/training_2.0.0/rcps_resnet.json
@@ -191,7 +191,31 @@
     },
     "Epochs to converge": [
       83, 85, 84, 86, 85, 85, 83, 84, 85, 85]
-  }
+  },
 
+  "resnet_ref_67840":
+  {
+    "Benchmark": "resnet",
+    "Creator": "NVIDIA",
+    "When": "At 2.0 submission",
+    "Platform": "TBD",
+    "BS": 67840,
+    "Hyperparams": {
+      "optimizer": "lars",
+      "opt_base_learning_rate": 24.699,
+      "opt_end_learning_rate": 0.0001,
+      "opt_learning_rate_decay_poly_power": 2,
+      "epsilon": 0,
+      "opt_learning_rate_warmup_epochs": 31,
+      "opt_momentum": 0.951807,
+      "opt_weight_decay": 0.0001,
+      "opt_learning_rate_decay_steps": 1133,
+      "model_bn_span": 424
+    },
+    "Epochs to converge": [
+	    86, 87, 86, 87, 86, 85, 86, 86, 86, 85, 86, 86, 86, 86, 86, 85, 86, 86, 87, 85, 85, 86, 85, 87, 86, 85, 85, 86
+    ]
+  }
+  
 }
 

--- a/mlperf_logging/rcp_checker/training_2.1.0/rcps_bert.json
+++ b/mlperf_logging/rcp_checker/training_2.1.0/rcps_bert.json
@@ -276,5 +276,28 @@
     "Epochs to converge": [
       4442880, 4592640, 4642560, 4842240, 4742400, 4592640, 4642560, 4692480, 4942080, 4542720,
       4592640, 4093440, 4442880, 4792320, 4642560, 4592640, 4592640, 4892160, 4742400, 4592640]
-  }
+  },
+
+  "bert_ref_16384":
+  {
+    "Benchmark": "bert",
+    "Creator": "NVIDIA",
+    "When": "At 2.0 submission",
+    "Platform": "TPU-v3-128",
+    "BS": 16384,
+    "Hyperparams": {
+        "opt_base_learning_rate": 0.0033,
+        "opt_epsilon": 1e-6,
+        "opt_learning_rate_training_steps": 600,
+        "num_warmup_steps": 290,
+        "start_warmup_step": -100,
+        "opt_lamb_beta_1": 0.75,
+        "opt_lamb_beta_2": 0.9,
+        "opt_lamb_weight_decay_rate": 0.0166629,
+        "gradient_accumulation_steps": 32
+    },
+    "Epochs to converge": [
+      5619712, 5770240, 5720064, 5419008, 5519360, 5569536, 5218304, 5469184, 5419008, 5218304,
+      5669888, 5669888, 5519360, 5569536, 5368832, 5469184, 5569536, 5469184, 5368832, 5469184]  
+    }
 }

--- a/mlperf_logging/rcp_checker/training_2.1.0/rcps_maskrcnn.json
+++ b/mlperf_logging/rcp_checker/training_2.1.0/rcps_maskrcnn.json
@@ -1,5 +1,23 @@
 {
 
+  "maskrcnn_ref_8":
+  {
+    "Benchmark": "maskrcnn",
+    "Creator": "NVIDIA",
+    "When": "Prior to 2.0 submission",
+    "Platform": "TBD",
+    "BS": 8,
+    "Hyperparams": {
+      "opt_learning_decay_steps": [144000, 192000],
+      "opt_base_learning_rate": 0.01,
+      "num_image_candidates": 1000,
+      "opt_learning_rate_warmup_factor": 0.00002,
+      "opt_learning_rate_warmup_steps": 500
+    },
+    "Epochs to converge": [
+       13, 13, 12, 13, 13, 13, 13, 12, 13, 12]
+  },
+  
   "maskrcnn_ref_48":
   {
     "Benchmark": "maskrcnn",

--- a/mlperf_logging/rcp_checker/training_2.1.0/rcps_resnet.json
+++ b/mlperf_logging/rcp_checker/training_2.1.0/rcps_resnet.json
@@ -191,6 +191,30 @@
     },
     "Epochs to converge": [
       83, 85, 84, 86, 85, 85, 83, 84, 85, 85]
+  },
+
+  "resnet_ref_67840":
+  {
+    "Benchmark": "resnet",
+    "Creator": "NVIDIA",
+    "When": "At 2.0 submission",
+    "Platform": "TBD",
+    "BS": 67840,
+    "Hyperparams": {
+      "optimizer": "lars",
+      "opt_base_learning_rate": 24.699,
+      "opt_end_learning_rate": 0.0001,
+      "opt_learning_rate_decay_poly_power": 2,
+      "epsilon": 0,
+      "opt_learning_rate_warmup_epochs": 31,
+      "opt_momentum": 0.951807,
+      "opt_weight_decay": 0.0001,
+      "opt_learning_rate_decay_steps": 1133,
+      "model_bn_span": 424
+    },
+    "Epochs to converge": [
+	    86, 87, 86, 87, 86, 85, 86, 86, 86, 85, 86, 86, 86, 86, 86, 85, 86, 86, 87, 85, 85, 86, 85, 87, 86, 85, 85, 86
+    ]
   }
 
 }


### PR DESCRIPTION
This PR: [https://github.com/mlcommons/logging/pull/238](https://github.com/mlcommons/logging/pull/238) from Training 2.0 was not merged.
So this is a new PR that adds those RCPs into both the training_2.0.0 and training_2.1.0 folders.

cc @johntran-nv @pgmpablo157321 