### PR TITLE
RCP checker refactor: interface cleanup

### DIFF
--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -165,7 +165,7 @@ def check_training_result_files(folder, usage, ruleset, quiet, werror,
                 rcp_chk._compute_rcp_stats()
 
                 # Now go again through result files to do RCP checks
-                rcp_pass, rcp_msg = rcp_chk._check_directory(benchmark_folder, rcp_pass='pruned_rcps', rcp_bypass=rcp_bypass, set_scaling=True)
+                rcp_pass, rcp_msg = rcp_chk.check_directory(benchmark_folder, rcp_pass='pruned_rcps', rcp_bypass=rcp_bypass, set_scaling=True)
                 if not rcp_pass:
                     logging.error('RCP Test Failed: %s', rcp_msg)
                     too_many_errors = True

--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -162,7 +162,7 @@ def check_training_result_files(folder, usage, ruleset, quiet, werror,
             # Run RCP checker for >= 1.0.0
             if ruleset in {'1.0.0', '1.1.0', '2.0.0', '2.1.0'} and division == 'closed' and benchmark != 'minigo':
                 rcp_chk = rcp_checker.make_checker(usage, ruleset, verbose=False, bert_train_samples=rcp_bert_train_samples)
-                rcp_chk._compute_rcp_stats()
+                rcp_chk.compute_rcp_stats()
 
                 # Now go again through result files to do RCP checks
                 rcp_pass, rcp_msg = rcp_chk.check_directory(benchmark_folder, rcp_pass='pruned_rcps', rcp_bypass=rcp_bypass, set_scaling=True)

--- a/mlperf_logging/rcp_checker/__main__.py
+++ b/mlperf_logging/rcp_checker/__main__.py
@@ -1,27 +1,3 @@
-import sys
-import logging
-
 from . import rcp_checker
 
-parser = rcp_checker.get_parser()
-args = parser.parse_args()
-
-logging.basicConfig(filename=args.log_output, level=logging.INFO)
-logging.getLogger().addHandler(logging.StreamHandler())
-formatter = logging.Formatter("%(levelname)s - %(message)s")
-logging.getLogger().handlers[0].setFormatter(formatter)
-logging.getLogger().handlers[1].setFormatter(formatter)
-
-# Results summarizer makes these 3 calls to invoke RCP test
-checker = rcp_checker.make_checker(args.rcp_usage, args.rcp_version, args.verbose, args.bert_train_samples)
-checker._compute_rcp_stats()
-# Check pruned RCPs by default. Use rcp_pass='full_rcp' for full check
-test, msg = checker._check_directory(args.dir, rcp_pass=args.rcp_pass)
-
-if test:
-    logging.info('%s, RCP test PASSED', msg)
-    print('** Logging output also at', args.log_output)
-else:
-    logging.error('%s, RCP test FAILED, consider adding --rcp_bypass in when running the package_checker.', msg)
-    print('** Logging output also at', args.log_output)
-    sys.exit(1)
+rcp_checker.main()

--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -194,7 +194,7 @@ class RCP_Checker:
                         self.pruned_rcp_data[record] = record_contents
 
 
-    def _compute_rcp_stats(self):
+    def compute_rcp_stats(self):
         '''Compute RCP mean, stdev and min acceptable epochs for RCPs'''
         for record, record_contents in self.rcp_data.items():
             epoch_list = record_contents['Epochs to converge']
@@ -503,7 +503,7 @@ def main():
 
     # Results summarizer makes these 3 calls to invoke RCP test
     checker = RCP_Checker(args.rcp_usage, args.rcp_version, args.verbose, args.bert_train_samples)
-    checker._compute_rcp_stats()
+    checker.compute_rcp_stats()
     # Check pruned RCPs by default. Use rcp_pass='full_rcp' for full check
     test, msg = checker.check_directory(args.dir, rcp_pass=args.rcp_pass)
 

--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -397,7 +397,7 @@ class RCP_Checker:
             return(False)
 
 
-    def _check_directory(self, dir, rcp_pass='full_rcp', rcp_bypass=False, set_scaling=False):
+    def check_directory(self, dir, rcp_pass='full_rcp', rcp_bypass=False, set_scaling=False):
         '''
         Check directory for RCP compliance.
         Returns (Pass/Fail, string with explanation)
@@ -505,7 +505,7 @@ def main():
     checker = RCP_Checker(args.rcp_usage, args.rcp_version, args.verbose, args.bert_train_samples)
     checker._compute_rcp_stats()
     # Check pruned RCPs by default. Use rcp_pass='full_rcp' for full check
-    test, msg = checker._check_directory(args.dir, rcp_pass=args.rcp_pass)
+    test, msg = checker.check_directory(args.dir, rcp_pass=args.rcp_pass)
 
     if test:
         logging.info('%s, RCP test PASSED', msg)


### PR DESCRIPTION
- Refactor `main` and `__main__.py` (Resolves #286)
- Rename methods (Resolves #287)