### PR TITLE
RCP checker refactor: load one benchmark

### DIFF
--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -161,11 +161,17 @@ def check_training_result_files(folder, usage, ruleset, quiet, werror,
 
             # Run RCP checker for >= 1.0.0
             if ruleset in {'1.0.0', '1.1.0', '2.0.0', '2.1.0'} and division == 'closed' and benchmark != 'minigo':
-                rcp_chk = rcp_checker.make_checker(usage, ruleset, verbose=False, bert_train_samples=rcp_bert_train_samples)
-                rcp_chk.compute_rcp_stats()
-
                 # Now go again through result files to do RCP checks
-                rcp_pass, rcp_msg = rcp_chk.check_directory(benchmark_folder, rcp_pass='pruned_rcps', rcp_bypass=rcp_bypass, set_scaling=True)
+                rcp_pass, rcp_msg = rcp_checker.check_directory(
+                        benchmark_folder,
+                        usage,
+                        ruleset,
+                        verbose=False,
+                        bert_train_samples=rcp_bert_train_samples,
+                        rcp_pass='pruned_rcps',
+                        rcp_bypass=rcp_bypass,
+                        set_scaling=True)
+
                 if not rcp_pass:
                     logging.error('RCP Test Failed: %s', rcp_msg)
                     too_many_errors = True

--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -35,8 +35,10 @@ submission_runs = {
 
 TOKEN = ':::MLLOG '
 
+
 def _print_divider_bar():
     logging.info('------------------------------')
+
 
 def read_submission_file(result_file, use_train_samples):
     not_converged = 1
@@ -80,6 +82,7 @@ def read_submission_file(result_file, use_train_samples):
     if not_converged:
         logging.warning(' Run incomplete or did not converge. Marking as infinite.')
     return not_converged, subm_epochs, bs, benchmark
+
 
 def get_submission_epochs(result_files, bert_train_samples):
     '''
@@ -235,7 +238,7 @@ class RCP_Checker:
         if rcp_pass == 'pruned_rcps':
             rcp_data = self.pruned_rcp_data
         elif rcp_pass == 'full_rcps':
-            rcp_data =  self.rcp_data
+            rcp_data = self.rcp_data
         return rcp_data
 
     def _find_rcp(self, bs, rcp_pass='full_rcp'):
@@ -450,7 +453,6 @@ def check_directory(dir, usage, version, verbose, bert_train_samples, rcp_pass='
         elif rcp_min is None and rcp_max is not None:
             rcp_min_record = checker._find_min_rcp(rcp_pass)
             rcp_check = checker._eval_submission_record(rcp_min_record, subm_epochs, (dir if set_scaling else ''))
-            mean_subm_epochs = np.mean(subm_epochs[1:len(subm_epochs)-1])
             if rcp_check is False:
                 rcp_msg = 'Missing RCP, please submit RCP with BS = {b}'.format(b=bs)
             else:
@@ -494,7 +496,7 @@ def get_parser():
 
 
 def make_checker(usage, ruleset, verbose=False, bert_train_samples=False):
-  return RCP_Checker(usage, ruleset, verbose, bert_train_samples)
+    return RCP_Checker(usage, ruleset, verbose, bert_train_samples)
 
 
 def main():
@@ -507,10 +509,7 @@ def main():
     logging.getLogger().handlers[0].setFormatter(formatter)
     logging.getLogger().handlers[1].setFormatter(formatter)
 
-    # Results summarizer makes these 3 calls to invoke RCP test
-    # checker = RCP_Checker(args.rcp_usage, args.rcp_version, args.verbose, args.bert_train_samples)
-    # checker.compute_rcp_stats()
-    # test, msg = checker.check_directory(args.dir, rcp_pass=args.rcp_pass)
+    # Package checker makes this call to invoke RCP test
     # Check pruned RCPs by default. Use rcp_pass='full_rcp' for full check
     passed, msg = check_directory(args.dir, args.rcp_usage, args.rcp_version, args.verbose, args.bert_train_samples, rcp_pass=args.rcp_pass)
 

--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -122,24 +122,23 @@ def get_submission_epochs(result_files, bert_train_samples):
 
 class RCP_Checker:
 
-    def __init__(self, usage, ruleset, verbose, bert_train_samples):
+    def __init__(self, usage, ruleset, benchmark, verbose):
         if ruleset not in {'1.0.0', "1.1.0", "2.0.0", "2.1.0"}:
             raise Exception('RCP Checker only supported in 1.0.0, 1.1.0, 2.0.0, 2.1.0')
         self.usage = usage
         self.ruleset = ruleset
+        self.benchmark = benchmark
         self.alpha = 0.05
         self.tolerance = 0.0001
         self.verbose = verbose
-        self.rcp_data = {}
-        self.bert_train_samples = bert_train_samples
-        self.submission_runs = submission_runs[usage]
+        self.submission_runs = submission_runs[usage][benchmark]
 
-        for benchmark in self.submission_runs.keys():
-            raw_rcp_data = self._consume_json_file(usage, ruleset, benchmark)
-            processed_rcp_data = self._process_raw_rcp_data(raw_rcp_data)
-            sorted_rcp_data = dict(sorted(processed_rcp_data.items(), key = lambda item: item[1]['BS']))
-            self.rcp_data.update(sorted_rcp_data)
+        raw_rcp_data = self._consume_json_file(usage, ruleset, self.benchmark)
+        processed_rcp_data = self._process_raw_rcp_data(raw_rcp_data)
+        sorted_rcp_data = dict(sorted(processed_rcp_data.items(), key=lambda item: item[1]['BS']))
+        self.rcp_data = sorted_rcp_data
 
+        self.compute_rcp_stats()
 
     def _consume_json_file(self, usage, ruleset, benchmark):
         '''Read json file'''
@@ -150,7 +149,6 @@ class RCP_Checker:
         #json_file = os.getcwd() + '/mlperf_logging/rcp_checker/' + ruleset + '/rcps_'+ benchmark+ '.json'
         with open(json_file, 'r') as f:
             return json.load(f)
-
 
     def _process_raw_rcp_data(self, raw_rcp_data):
         '''
@@ -171,7 +169,6 @@ class RCP_Checker:
             # numbers out of bounds, etc.
         return processed_rcps
 
-
     def _prune_rcps(self):
         '''
         Prune RCPs. We compare convergence of each RCP point with interpolation using surrounding points
@@ -179,42 +176,39 @@ class RCP_Checker:
         pruned_rcp_data is by default used for RCP tests.
         '''
         self.pruned_rcp_data = {}
-        for benchmark in submission_runs[self.usage].keys():
-            min_epochs = []
+        # TODO: pruning should be done in dictionary instead of list to avoid nested loop at the end
+        min_epochs = list(self.rcp_data.values())
+
+        # Step 1
+        # Find point with fastest convergence and prune all point with smaller batch size
+        # In that way the min batch size point will have the fastest convergenece
+        fastest_conv = min(min_epochs, key=lambda rc: rc['Min Epochs'])
+        min_epochs = list(filter(lambda rc: rc['BS'] >= fastest_conv['BS'], min_epochs))
+
+        # Step 2
+        # Run this algorithm for the rest of the points:
+        # for i = 1..N-2
+        #    if RCP[i+1] has slower convergence than interpolation(RCP[i], RCP[i+2]):
+        #      remove it
+        #      decrement i,N
+        list_len = len(min_epochs)
+        i = 1
+        # this loop does pruning, but it's not calculating the lower convex envelope
+        while i < list_len - 1:
+            rcp_min = min_epochs[i-1]
+            rcp_max = min_epochs[i+1]
+            bs = min_epochs[i]['BS']
+            name, rcp = self._create_interp_rcp(bs, rcp_min, rcp_max)
+            if min_epochs[i]['Min Epochs'] > rcp['Min Epochs']:
+                del min_epochs[i]
+                i = i-1
+                list_len = list_len - 1
+            i = i+1
+
+        for min_epoch in min_epochs:
             for record, record_contents in self.rcp_data.items():
-                if record_contents['Benchmark'] == benchmark:
-                    min_epochs.append(record_contents)
-
-            # Step 1
-            # Find point with fastest convergence and prune all point with smaller batch size
-            # In that way the min batch size point will have the fastest convergenece
-            fastest_conv = min(min_epochs, key=lambda rc: rc['Min Epochs'])
-            min_epochs = list(filter(lambda rc: rc['BS'] >= fastest_conv['BS'], min_epochs))
-
-            # Step 2
-            # Run this algorithm for the rest of the points:
-            # for i = 1..N-2
-            #    if RCP[i+1] has slower convergence than interpolation(RCP[i], RCP[i+2]):
-            #      remove it
-            #      decrement i,N
-            list_len = len(min_epochs)
-            i = 1
-            while i < list_len - 1:
-                rcp_min = min_epochs[i-1]
-                rcp_max = min_epochs[i+1]
-                bs = min_epochs[i]['BS']
-                name, rcp = self._create_interp_rcp(benchmark,bs,rcp_min,rcp_max)
-                if min_epochs[i]['Min Epochs'] > rcp['Min Epochs']:
-                    del min_epochs[i]
-                    i = i-1
-                    list_len = list_len - 1
-                i = i+1
-
-            for min_epoch in min_epochs:
-                for record, record_contents in self.rcp_data.items():
-                    if record_contents['Benchmark'] == min_epoch['Benchmark'] and record_contents['BS'] == min_epoch['BS']:
-                        self.pruned_rcp_data[record] = record_contents
-
+                if record_contents['Benchmark'] == min_epoch['Benchmark'] and record_contents['BS'] == min_epoch['BS']:
+                    self.pruned_rcp_data[record] = record_contents
 
     def compute_rcp_stats(self):
         '''Compute RCP mean, stdev and min acceptable epochs for RCPs'''
@@ -226,7 +220,6 @@ class RCP_Checker:
             record_contents['RCP Mean'] = np.mean(epoch_list[samples_rejected:len(epoch_list)-samples_rejected])
             record_contents['RCP Stdev'] = np.std(epoch_list[samples_rejected:len(epoch_list)-samples_rejected])
             min_epochs = self._find_min_acceptable_mean(
-                              record_contents['Benchmark'],
                               record_contents['RCP Mean'],
                               record_contents['RCP Stdev'],
                               len(epoch_list)-samples_rejected*2)
@@ -238,35 +231,32 @@ class RCP_Checker:
 
         self._prune_rcps()
 
-
-    def _get_rcp_data(self, rcp_pass = 'pruned_rcps'):
+    def _get_rcp_data(self, rcp_pass='pruned_rcps'):
         if rcp_pass == 'pruned_rcps':
             rcp_data = self.pruned_rcp_data
         elif rcp_pass == 'full_rcps':
             rcp_data =  self.rcp_data
         return rcp_data
 
-
-    def _find_rcp(self, benchmark, bs, rcp_pass = 'full_rcp'):
-        '''Find RCP based on benchmark and batch size'''
+    def _find_rcp(self, bs, rcp_pass='full_rcp'):
+        '''Find RCP based on batch size'''
         rcp_data = self._get_rcp_data(rcp_pass)
         for _, record_contents in rcp_data.items():
-            if record_contents['Benchmark'] == benchmark and record_contents['BS'] == bs:
+            if record_contents['BS'] == bs:
                 return record_contents
 
-
-    def _find_min_rcp(self, benchmark, rcp_pass = 'full_rcp'):
+    def _find_min_rcp(self, rcp_pass='full_rcp'):
         '''Find RCP with the smallest batch size for a benchmark'''
         min_bs = 1e9
         min_record = None
         rcp_data = self._get_rcp_data(rcp_pass)
         for _, record_contents in rcp_data.items():
-            if record_contents['BS'] < min_bs and record_contents['Benchmark'] == benchmark:
+            if record_contents['BS'] < min_bs:
                 min_record = record_contents
                 min_bs = record_contents['BS']
         return min_record
 
-    def _find_top_min_rcp(self, benchmark, bs, rcp_pass = 'full_rcp'):
+    def _find_top_min_rcp(self, bs, rcp_pass='full_rcp'):
         '''
         Find top RCP to serve as min in interpolation.
         For example, if bs = 100 and reference has bs = 10, 20, 110, 120
@@ -276,14 +266,12 @@ class RCP_Checker:
         min_record = None
         rcp_data = self._get_rcp_data(rcp_pass)
         for _, record_contents in rcp_data.items():
-            if record_contents['Benchmark'] == benchmark:
-                if record_contents['BS'] < bs and record_contents['BS'] > min_bs:
-                    min_bs = record_contents['BS']
-                    min_record = record_contents
+            if record_contents['BS'] < bs and record_contents['BS'] > min_bs:
+                min_bs = record_contents['BS']
+                min_record = record_contents
         return min_record
 
-
-    def _find_bottom_max_rcp(self, benchmark, bs, rcp_pass = 'full_rcp'):
+    def _find_bottom_max_rcp(self, bs, rcp_pass='full_rcp'):
         '''
         Find bottom RCP to serve as max in interpolation.
         For example, if bs = 100 and reference has bs = 10, 20, 110, 120
@@ -293,12 +281,10 @@ class RCP_Checker:
         max_record = None
         rcp_data = self._get_rcp_data(rcp_pass)
         for _, record_contents in rcp_data.items():
-            if record_contents['Benchmark'] == benchmark:
-                if record_contents['BS'] > bs and record_contents['BS'] < max_bs:
-                    max_bs = record_contents['BS']
-                    max_record = record_contents
+            if record_contents['BS'] > bs and record_contents['BS'] < max_bs:
+                max_bs = record_contents['BS']
+                max_record = record_contents
         return max_record
-
 
     def _find_p_value(self, subm_mean, subm_stdev, subm_num_samples,
                       ref_mean, ref_stdev, ref_num_samples,
@@ -320,8 +306,7 @@ class RCP_Checker:
             p_value = 1 - (p_value / 2)
         return p_value > alpha, p_value
 
-
-    def _find_min_acceptable_mean(self, benchmark, mean, stdev, num_samples_ref):
+    def _find_min_acceptable_mean(self, mean, stdev, num_samples_ref):
         '''
         Do a binary search to find the min acceptable epoch mean to converge
         The limits are 0 and the reference mean, anything above reference is acceptable
@@ -329,7 +314,7 @@ class RCP_Checker:
 
         if stdev == 0:
             return mean
-        num_samples_subm = self.submission_runs[benchmark] - 2
+        num_samples_subm = self.submission_runs - 2
         mean_max = mean
         mean_min = 0.0
         mean_mid = (mean_min + mean_max) / 2
@@ -348,8 +333,7 @@ class RCP_Checker:
 
         return mean_mid
 
-
-    def _create_interp_rcp(self, benchmark, target_bs, low_rcp, high_rcp):
+    def _create_interp_rcp(self, target_bs, low_rcp, high_rcp):
         '''
         Create an interpolation RCP for batch size target_bs by interpolating
         low_rcp and high_rcp. Add the RCP into rcp_data.
@@ -365,12 +349,11 @@ class RCP_Checker:
                     [low_rcp['RCP Stdev'], high_rcp['RCP Stdev']])
 
         min_epochs = self._find_min_acceptable_mean(
-                         benchmark,
                          mean,
                          stdev,
-                         self.submission_runs[benchmark]*2)
-        interp_record_name = benchmark + '_interp_' + str(target_bs)
-        interp_record = {'Benchmark': benchmark,
+                         self.submission_runs*2)
+        interp_record_name = self.benchmark + '_interp_' + str(target_bs)
+        interp_record = {'Benchmark': self.benchmark,
                          'BS': target_bs,
                          'Hyperparams': {},
                          'Epochs to converge': [],
@@ -412,76 +395,78 @@ class RCP_Checker:
                 if results_dir != '':
                     self._set_results_scaling(norm_factor, results_dir)
                     logging.info(" Results scaling set to normalization factor of %.4f", norm_factor)
-            return(True)
+            return True
         else:
             logging.info(" RCP Record: %s", rcp_record)
             logging.info(" Submission mean epochs: %.4f", mean_subm_epochs)
-            return(False)
+            return False
 
 
-    def check_directory(self, dir, rcp_pass='full_rcp', rcp_bypass=False, set_scaling=False):
-        '''
-        Check directory for RCP compliance.
-        Returns (Pass/Fail, string with explanation)
-        Possible cases, the top 3 fail before RCP check.
-        - (False) Fail / did not find global_batch_size in log
-        - (False) Fail / run failed to converge
-        - (False) Fail / Benchmark w/o RCP records
-        - (True) Pass / RCP found
-        - (True) Pass / RCP interpolated
-        - (True) Pass / RCP missing but submission converges slower on smaller batch size
-        - (False --> True with --rcp_bypass when running from package checker) Fail / RCP found
-        - (False --> True with --rcp_bypass when running from package checker) Fail / RCP interpolated
-        - (False --> True with --rcp_bypass when running from package checker) Missing RCP / Submit missing RCP
-        '''
-        _print_divider_bar()
-        logging.info(" Running RCP Checker, pass: %s", rcp_pass)
-        _print_divider_bar()
-        dir = dir.rstrip("/")
-        pattern = '{folder}/result_*.txt'.format(folder=dir)
-        result_files = glob.glob(pattern, recursive=True)
-        bs, subm_epochs, benchmark = get_submission_epochs(result_files, self.bert_train_samples)
+def check_directory(dir, usage, version, verbose, bert_train_samples, rcp_pass='full_rcp', rcp_bypass=False, set_scaling=False):
+    '''
+    Check directory for RCP compliance.
+    Returns (Pass/Fail, string with explanation)
+    Possible cases, the top 3 fail before RCP check.
+    - (False) Fail / did not find global_batch_size in log
+    - (False) Fail / run failed to converge
+    - (False) Fail / Benchmark w/o RCP records
+    - (True) Pass / RCP found
+    - (True) Pass / RCP interpolated
+    - (True) Pass / RCP missing but submission converges slower on smaller batch size
+    - (False --> True with --rcp_bypass when running from package checker) Fail / RCP found
+    - (False --> True with --rcp_bypass when running from package checker) Fail / RCP interpolated
+    - (False --> True with --rcp_bypass when running from package checker) Missing RCP / Submit missing RCP
+    '''
+    _print_divider_bar()
+    logging.info(" Running RCP Checker, pass: %s", rcp_pass)
+    _print_divider_bar()
+    dir = dir.rstrip("/")
+    pattern = '{folder}/result_*.txt'.format(folder=dir)
+    result_files = glob.glob(pattern, recursive=True)
+    bs, subm_epochs, benchmark = get_submission_epochs(result_files, bert_train_samples)
 
-        if bs == -1:
-            return False, 'Could not detect global_batch_size'
-        if subm_epochs is None:
-            return False, 'Insufficient convergence'
+    checker = RCP_Checker(usage, version, benchmark, verbose)
 
-        rcp_record = self._find_rcp(benchmark, bs, rcp_pass)
-        rcp_msg = ''
-        if rcp_record is not None:
-            rcp_msg = 'RCP found'
-            rcp_check = self._eval_submission_record(rcp_record, subm_epochs, (dir if set_scaling else ''))
-        else:
-            rcp_min = self._find_top_min_rcp(benchmark, bs, rcp_pass)
-            rcp_max = self._find_bottom_max_rcp(benchmark, bs, rcp_pass)
-            if rcp_min is not None and rcp_max is not None:
-                rcp_msg = 'RCP Interpolation'
-                interp_record_name, interp_record = self._create_interp_rcp(benchmark, bs, rcp_min, rcp_max)
-                rcp_check = self._eval_submission_record(interp_record, subm_epochs, (dir if set_scaling else ''))
-            elif rcp_min is not None and rcp_max is None:
+    if bs == -1:
+        return False, 'Could not detect global_batch_size'
+    if subm_epochs is None:
+        return False, 'Insufficient convergence'
+
+    rcp_record = checker._find_rcp(bs, rcp_pass)
+    rcp_msg = ''
+    if rcp_record is not None:
+        rcp_msg = 'RCP found'
+        rcp_check = checker._eval_submission_record(rcp_record, subm_epochs, (dir if set_scaling else ''))
+    else:
+        rcp_min = checker._find_top_min_rcp(bs, rcp_pass)
+        rcp_max = checker._find_bottom_max_rcp(bs, rcp_pass)
+        if rcp_min is not None and rcp_max is not None:
+            rcp_msg = 'RCP Interpolation'
+            interp_record_name, interp_record = checker._create_interp_rcp(bs, rcp_min, rcp_max)
+            rcp_check = checker._eval_submission_record(interp_record, subm_epochs, (dir if set_scaling else ''))
+        elif rcp_min is not None and rcp_max is None:
+            rcp_msg = 'Missing RCP, please submit RCP with BS = {b}'.format(b=bs)
+            rcp_check = False
+        elif rcp_min is None and rcp_max is not None:
+            rcp_min_record = checker._find_min_rcp(rcp_pass)
+            rcp_check = checker._eval_submission_record(rcp_min_record, subm_epochs, (dir if set_scaling else ''))
+            mean_subm_epochs = np.mean(subm_epochs[1:len(subm_epochs)-1])
+            if rcp_check is False:
                 rcp_msg = 'Missing RCP, please submit RCP with BS = {b}'.format(b=bs)
-                rcp_check = False
-            elif rcp_min is None and rcp_max is not None:
-                rcp_min_record = self._find_min_rcp(benchmark, rcp_pass)
-                rcp_check = self._eval_submission_record(rcp_min_record, subm_epochs, (dir if set_scaling else ''))
-                mean_subm_epochs = np.mean(subm_epochs[1:len(subm_epochs)-1])
-                if rcp_check == False:
-                   rcp_msg = 'Missing RCP, please submit RCP with BS = {b}'.format(b=bs)
-                else:
-                   rcp_msg = 'RCP not found but slower convergence on smaller batch size'
             else:
-                rcp_check = False
-                rcp_msg = 'Cannot find any RCPs'
+                rcp_msg = 'RCP not found but slower convergence on smaller batch size'
+        else:
+            rcp_check = False
+            rcp_msg = 'Cannot find any RCPs'
 
-        if rcp_bypass and not rcp_check:
-            if rcp_msg == 'RCP found' or rcp_msg == 'RCP Interpolation' or rcp_msg == 'Missing RCP, please submit RCP with BS = {b}'.format(b=bs):
-                rcp_msg  = rcp_msg + ' passed using rcp_bypass'
-                logging.warning(' RCP test failed but allowed to proceed with RCP bypass.')
-                logging.warning(' Please be ready to have this reviewed by the submission committee.')
-                rcp_check = True
+    if rcp_bypass and not rcp_check:
+        if rcp_msg == 'RCP found' or rcp_msg == 'RCP Interpolation' or rcp_msg == 'Missing RCP, please submit RCP with BS = {b}'.format(b=bs):
+            rcp_msg = rcp_msg + ' passed using rcp_bypass'
+            logging.warning(' RCP test failed but allowed to proceed with RCP bypass.')
+            logging.warning(' Please be ready to have this reviewed by the submission committee.')
+            rcp_check = True
 
-        return rcp_check, rcp_msg
+    return rcp_check, rcp_msg
 
 
 def get_parser():
@@ -523,10 +508,11 @@ def main():
     logging.getLogger().handlers[1].setFormatter(formatter)
 
     # Results summarizer makes these 3 calls to invoke RCP test
-    checker = RCP_Checker(args.rcp_usage, args.rcp_version, args.verbose, args.bert_train_samples)
-    checker.compute_rcp_stats()
+    # checker = RCP_Checker(args.rcp_usage, args.rcp_version, args.verbose, args.bert_train_samples)
+    # checker.compute_rcp_stats()
+    # test, msg = checker.check_directory(args.dir, rcp_pass=args.rcp_pass)
     # Check pruned RCPs by default. Use rcp_pass='full_rcp' for full check
-    passed, msg = checker.check_directory(args.dir, rcp_pass=args.rcp_pass)
+    passed, msg = check_directory(args.dir, args.rcp_usage, args.rcp_version, args.verbose, args.bert_train_samples, rcp_pass=args.rcp_pass)
 
     if passed:
         logging.info('%s, RCP test PASSED', msg)
@@ -535,6 +521,7 @@ def main():
         logging.error('%s, RCP test FAILED, consider adding --rcp_bypass in when running the package_checker.', msg)
         print('** Logging output also at', args.log_output)
         sys.exit(1)
+
 
 if __name__ == '__main__':
     main()

--- a/mlperf_logging/result_summarizer/result_summarizer.py
+++ b/mlperf_logging/result_summarizer/result_summarizer.py
@@ -17,7 +17,6 @@ import pandas as pd
 from ..compliance_checker import mlp_compliance
 from ..compliance_checker.mlp_compliance import usage_choices, rule_choices
 from ..compliance_checker.mlp_parser import parse_file
-from ..rcp_checker import rcp_checker
 
 from ..benchmark_meta import get_allowed_benchmarks, get_result_file_counts
 


### PR DESCRIPTION
- Split `check_directory()` from `RCP_Checker` class
- `RCP_Checker` created for only 1 benchmark, only reads RCPs and maintains state for 1 benchmark
- `RCP_Checker` state and stats computed (`compute_rcp_stats()`) at initialization
- `check_directory()` creates a checker with benchmark read from `get_submission_epochs()`

To check a results directory, now only need to call `check_directory()`

Depends #289 , #293 