### PR TITLE
[DLRMv2] RCP for BS=102400

### DIFF
--- a/mlperf_logging/rcp_checker/training_3.0.0/rcps_dlrmv2.json
+++ b/mlperf_logging/rcp_checker/training_3.0.0/rcps_dlrmv2.json
@@ -1,0 +1,27 @@
+{
+  "dlrmv2_ref_102400": {
+    "Benchmark": "dlrmv2",
+    "Creator": "NVIDIA",
+    "When": "Prior to 3.0 submission",
+    "Platform": "DGX-A100",
+    "BS": 102400,
+    "Hyperparams": {
+      "opt_name": "adagrad",
+      "opt_base_learning_rate": 0.004,
+      "opt_adagrad_learning_rate_decay": 0.0,
+      "opt_adagrad_initial_accumulator_value": 0.0,
+      "opt_adagrad_epsilon": 1e-08,
+      "opt_weight_decay": 0.0,
+      "opt_learning_rate_warmup_steps": 0,
+      "opt_learning_rate_decay_start_step": 0,
+      "opt_learning_rate_decay_steps": 0
+    },
+    "Epochs to converge": [
+      0.85, 0.95, 0.95, 0.85, 0.9, 0.8, 0.85, 0.9, 0.9, 0.9,
+      0.95, 0.9, 0.9, 0.9, 0.9, 0.9, 0.85, 0.85, 0.9, 0.9,
+      0.8, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.85, 0.9, 0.9,
+      0.9, 0.95, 0.85, 0.9, 0.9, 0.9, 0.85, 0.9, 0.95, 0.9,
+      0.85, 0.95, 0.9, 0.9, 0.8, 0.9, 0.9, 0.9, 0.85, 0.9
+    ]
+  }
+}


### PR DESCRIPTION
I'm adding initial RCPs data for the new recommender DLRMv2 benchmark for MLPerf Training v3.0.0.

1. Command to generate the data is:
```shell
# Parameters
GLOBAL_BATCH_SIZE=102400
LEARNING_RATE=0.004

# Constants
TOTAL_TRAINING_SAMPLES=4195197692
NUM_EMBEDDINGS=40000000,39060,17295,7424,20265,3,7122,1543,63,40000000,3067956,405282,10,2209,11938,155,4,976,14,40000000,40000000,40000000,590152,12973,108,36
WORLD_SIZE=8
NUM_EVAL=20

torchx run -s local_cwd dist.ddp -j 1x8 --script dlrm_main.py -- \
    --synthetic_multi_hot_criteo_path /data \
    --mmap_mode \
    --pin_memory \
    --epochs 1 \
    --embedding_dim 128 \
    --dense_arch_layer_sizes 512,256,128 \
    --over_arch_layer_sizes 1024,1024,512,256,1 \
    --interaction_type dcn \
    --dcn_num_layers 3 \
    --dcn_low_rank_dim 512 \
    --validation_freq_within_epoch $((TOTAL_TRAINING_SAMPLES / (GLOBAL_BATCH_SIZE * NUM_EVAL))) \
    --validation_auroc 0.80275 \
    --num_embeddings_per_feature ${NUM_EMBEDDINGS} \
    --batch_size $((GLOBAL_BATCH_SIZE / WORLD_SIZE)) \
    --drop_last_training_batch \
    --test_batch_size 131072 \
    --adagrad \
    --learning_rate ${LEARNING_RATE}
```
2. Total number of jobs run is 50, all of them were successful in the sense that they converged within one epoch

3. For convenience aggregate results are:

|   Epochs to converge |  Fraction or runs |
|:-------:|:-----:|
|    0.8    |    6% |
|    0.85  | 20%  |
|    0.9    |  62% |
|    0.95  |  12% |