### PR TITLE
Make score normalization factor available in module

### DIFF
--- a/mlperf_logging/package_checker/package_checker.py
+++ b/mlperf_logging/package_checker/package_checker.py
@@ -162,7 +162,7 @@ def check_training_result_files(folder, usage, ruleset, quiet, werror,
             # Run RCP checker for >= 1.0.0
             if ruleset in {'1.0.0', '1.1.0', '2.0.0', '2.1.0'} and division == 'closed' and benchmark != 'minigo':
                 # Now go again through result files to do RCP checks
-                rcp_pass, rcp_msg = rcp_checker.check_directory(
+                rcp_pass, rcp_msg, _ = rcp_checker.check_directory(
                         benchmark_folder,
                         usage,
                         ruleset,


### PR DESCRIPTION
`_eval_submission_record` and `check_directory` return the score normalization factor for use in other python scripts/modules.
This return value is ignored in the package checker and rcp checker `main` calls to `check_directory`.