### PR TITLE
[DLRMv2] RCPs for BS=32768 and BS=65536

### DIFF
--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -20,6 +20,7 @@ submission_runs = {
     "training": {
         'bert': 10,
         'dlrm': 5,
+        'dlrmv2': 5,
         'maskrcnn' : 5,
         'resnet' : 5,
         'ssd' : 5,

--- a/mlperf_logging/rcp_checker/training_3.0.0/rcps_dlrmv2.json
+++ b/mlperf_logging/rcp_checker/training_3.0.0/rcps_dlrmv2.json
@@ -1,4 +1,53 @@
 {
+
+  "dlrmv2_ref_32768": {
+    "Benchmark": "dlrmv2",
+    "Creator": "NVIDIA",
+    "When": "Prior to 3.0 submission",
+    "Platform": "DGX-A100",
+    "BS": 32768,
+    "Hyperparams": {
+      "opt_name": "adagrad",
+      "opt_base_learning_rate": 0.004,
+      "opt_adagrad_learning_rate_decay": 0.0,
+      "opt_adagrad_initial_accumulator_value": 0.0,
+      "opt_adagrad_epsilon": 1e-08,
+      "opt_weight_decay": 0.0,
+      "opt_learning_rate_warmup_steps": 0,
+      "opt_learning_rate_decay_start_step": 0,
+      "opt_learning_rate_decay_steps": 0
+    },
+    "Epochs to converge": [
+      0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7,
+      0.75, 0.7, 0.7, 0.7, 0.75, 0.75, 0.75, 0.7, 0.7, 0.7,
+      0.7, 0.7, 0.75, 0.7, 0.65, 0.7, 0.7, 0.7, 0.7, 0.7
+    ]
+  },
+
+  "dlrmv2_ref_65536": {
+    "Benchmark": "dlrmv2",
+    "Creator": "NVIDIA",
+    "When": "Prior to 3.0 submission",
+    "Platform": "DGX-A100",
+    "BS": 65536,
+    "Hyperparams": {
+      "opt_name": "adagrad",
+      "opt_base_learning_rate": 0.004,
+      "opt_adagrad_learning_rate_decay": 0.0,
+      "opt_adagrad_initial_accumulator_value": 0.0,
+      "opt_adagrad_epsilon": 1e-08,
+      "opt_weight_decay": 0.0,
+      "opt_learning_rate_warmup_steps": 0,
+      "opt_learning_rate_decay_start_step": 0,
+      "opt_learning_rate_decay_steps": 0
+    },
+    "Epochs to converge": [
+      0.75, 0.8, 0.75, 0.75, 0.8, 0.75, 0.8, 0.9, 0.95, 0.75,
+      0.75, 0.75, 0.85, 0.85, 0.7, 0.75, 0.75, 0.9, 0.85, 0.8,
+      0.7, 0.75, 0.75, 0.75, 0.8, 0.9, 0.75, 0.8, 0.85, 0.8
+    ]
+  },
+
   "dlrmv2_ref_102400": {
     "Benchmark": "dlrmv2",
     "Creator": "NVIDIA",
@@ -24,4 +73,5 @@
       0.85, 0.95, 0.9, 0.9, 0.8, 0.9, 0.9, 0.9, 0.85, 0.9
     ]
   }
+
 }


### PR DESCRIPTION
I'm adding extra RCPs data for the new recommender DLRMv2 benchmark for MLPerf Training v3.0.0.

1. Command to generate the data:
```
# Parameters
GLOBAL_BATCH_SIZE=32768  # or 65536
LEARNING_RATE=0.004

# Constants
TOTAL_TRAINING_SAMPLES=4195197692
NUM_EMBEDDINGS=40000000,39060,17295,7424,20265,3,7122,1543,63,40000000,3067956,405282,10,2209,11938,155,4,976,14,40000000,40000000,40000000,590152,12973,108,36
WORLD_SIZE=8
NUM_EVAL=20

torchx run -s local_cwd dist.ddp -j 1x8 --script dlrm_main.py -- \
    --synthetic_multi_hot_criteo_path /data \
    --mmap_mode \
    --pin_memory \
    --epochs 1 \
    --embedding_dim 128 \
    --dense_arch_layer_sizes 512,256,128 \
    --over_arch_layer_sizes 1024,1024,512,256,1 \
    --interaction_type dcn \
    --dcn_num_layers 3 \
    --dcn_low_rank_dim 512 \
    --validation_freq_within_epoch $((TOTAL_TRAINING_SAMPLES / (GLOBAL_BATCH_SIZE * NUM_EVAL))) \
    --validation_auroc 0.80275 \
    --num_embeddings_per_feature ${NUM_EMBEDDINGS} \
    --batch_size $((GLOBAL_BATCH_SIZE / WORLD_SIZE)) \
    --drop_last_training_batch \
    --test_batch_size 131072 \
    --adagrad \
    --learning_rate ${LEARNING_RATE}
```
2. 30 experiments were run for the two batch sizes tested, all converged within one epoch
3. For convenience aggregate results are:

**BS=32768**

Average epoch to converge: 0.71.

| Epochs to converge  | Fraction or runs  |
|:-------:|:----|
|  0.65   | 3%  |
|   0.7   | 80% |
|  0.75   | 17% |

**BS=65536**

Average epoch to converge: 0.79.

|  Epochs to converge  | Fraction or runs |
|:-------:|:----|
|   0.7   | 7%  |
|  0.75   | 43% |
|   0.8   | 23% |
|  0.85   | 13% |
|   0.9   | 10% |
|  0.95   | 3%  |