### PR TITLE
Fix run stop check

### DIFF
--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -84,7 +84,7 @@ def read_submission_file(result_file, use_train_samples):
                     eval_accuracy_str = str
                     conv_epoch = json.loads(eval_accuracy_str)["value"]
         
-                if "run_stop" in str:
+                if "run_stop" in str and json.loads(str)["key"] == "run_stop":
                     conv_result = json.loads(str)["metadata"]["status"]
                     if conv_result == "success":
                         not_converged = 0


### PR DESCRIPTION
Existing check will pass on lines such as:
```
:::MLLOG {"namespace": "", "time_ms": 1684006089927, "event_type": "POINT_IN_TIME", "key": "eval_accuracy", "value": {0}, "metadata": {"file": "check_run_stop.py", "lineno": 411, "epoch_num": 16}}
```
This is line contains 'run_stop' string, but this is not a run_stop event, in which case 'run_stop' is the key.
