### PR TITLE
remove redundant/extraneous submission_org and submission_platform fields from compliance checks before training v5.0

### DIFF
--- a/mlperf_logging/compliance_checker/training_5.0.0/closed_common.yaml
+++ b/mlperf_logging/compliance_checker/training_5.0.0/closed_common.yaml
@@ -3,7 +3,7 @@
     NAME:  submission_benchmark
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] in ['retinanet', 'stable_diffusion', 'dlrm_dcnv2', 'bert', 'rgat', 'llama2_70b_lora'] "
-    POST:  " enqueue_config('training_4.1.0/closed_{}.yaml'.format(v['value'])) "
+    POST:  " enqueue_config('training_5.0.0/closed_{}.yaml'.format(v['value'])) "
 
 - KEY:
     NAME: gradient_accumulation_steps

--- a/mlperf_logging/compliance_checker/training_5.0.0/common.yaml
+++ b/mlperf_logging/compliance_checker/training_5.0.0/common.yaml
@@ -32,7 +32,7 @@
     NAME:  submission_division
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] in ['closed', 'open'] "
-    POST:  " enqueue_config('training_4.1.0/{}_common.yaml'.format(v['value'])); s['compile_time_mins'] = 240 if v['value'] == 'open' else 30 "
+    POST:  " enqueue_config('training_5.0.0/{}_common.yaml'.format(v['value'])); s['compile_time_mins'] = 240 if v['value'] == 'open' else 30 "
 
 # at least one record should be found, but any found records must pass the test
 - KEY:

--- a/mlperf_logging/compliance_checker/training_5.0.0/common.yaml
+++ b/mlperf_logging/compliance_checker/training_5.0.0/common.yaml
@@ -29,16 +29,6 @@
         })
 
 - KEY:
-    NAME:  submission_org
-    REQ:   EXACTLY_ONE
-    CHECK: " v['value'] != '' "
-
-- KEY:
-    NAME:  submission_platform
-    REQ:   EXACTLY_ONE
-    CHECK: " v['value'] != '' "
-
-- KEY:
     NAME:  submission_division
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] in ['closed', 'open'] "

--- a/mlperf_logging/compliance_checker/training_5.0.0/open_common.yaml
+++ b/mlperf_logging/compliance_checker/training_5.0.0/open_common.yaml
@@ -3,4 +3,4 @@
     NAME:  submission_benchmark
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] in ['retinanet', 'stable_diffusion', 'dlrm_dcnv2', 'bert', 'rgat', 'llama2_70b_lora'] "
-    POST:  " enqueue_config('training_4.1.0/open_{}.yaml'.format(v['value'])) "
+    POST:  " enqueue_config('training_5.0.0/open_{}.yaml'.format(v['value'])) "


### PR DESCRIPTION
There are a number of fields in the `results.txt` files that were made redundant (and therefor error prone and inconsistent) when we introduced the `systems/*.json` files in v1.0.

This PR removes the compliance checker checks for the `submission_org` and `submission_platform` fields from the training v5.0.0 compliance checker `common.yaml` file.

These two fields in the `result*.txt` files are redundant, and (other than their presence) are not used for anything or checked by any of the compliance or package checkers. They are difficult for many submitters to get correct in their submissions, and are often a source of confusion and/or extra work during the submission review period.

Historically, there were originally 4 fields:

1. `submission_platform` which is redundant with some combination of the sys.json `system_name`, and `number_of_nodes` fields. This PR removes the compliance check for this field from training v5.0.0.
2. `submission_org` which is now redundant with the sys.json submitter field. This PR removes the compliance check for this field from training v5.0.0.
3. `submission_status` which was replaced by the sys.json `status` field, and removed from the compliance checker before the v4.1.0 round (since it used values inconsistent with the values used in the sys.json).
4. `submission_division` which is now redundant with the sys.json `division` field. This PR does not remove the compliance check for this field from training v5.0.0 because the compliance checker uses this field to determine whether the maximal allowed initialization time is 30 minutes (closed division) or 240 minutes (open division).

NOTE:  This PR also fixes three cases where the v5.0 yamls were not updated correctly when they were copied over from v4.1.