### PR TITLE
Update rcp_checker.py to handle llama31_8b epochs correctly

### DIFF
--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -84,7 +84,7 @@ def read_submission_file(result_file, ruleset, use_train_samples):
                     eval_metric = json.loads(eval_accuracy_str)["metadata"]["metric"]
                     eval_score = json.loads(eval_accuracy_str)["value"]
                     stable_diffusion_eval_results[eval_step][eval_metric] = eval_score
-                elif benchmark in {"llama2_70b_lora", "flux1", "llama31_405b"} and ("eval_error" in str or "eval_accuracy" in str):
+                elif benchmark in {"llama2_70b_lora", "flux1", "llama31_405b", "llama31_8b"} and ("eval_error" in str or "eval_accuracy" in str):
                     eval_accuracy_str = str
                     conv_epoch = json.loads(eval_accuracy_str)["metadata"]["samples_count"]
                     eval_score = json.loads(eval_accuracy_str)["value"]


### PR DESCRIPTION
Right now the RCP check fails for llama3 using the reference implementation. It throws an error because it trries to get the epch from epoch_nums instead of sample_count:
```
  File "/home/gyuzakor/actions-runner/_work/_tool/Python/3.12.11/x64/lib/python3.12/site-packages/mlperf_logging/rcp_checker/rcp_checker.py", line 496, in check_directory
    bs, subm_epochs, benchmark = get_submission_epochs(result_files, version, bert_train_samples)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gyuzakor/actions-runner/_work/_tool/Python/3.12.11/x64/lib/python3.12/site-packages/mlperf_logging/rcp_checker/rcp_checker.py", line 136, in get_submission_epochs
    curr_not_converged, curr_subm_epochs, curr_bs, curr_benchmark = read_submission_file(
                                                                    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/gyuzakor/actions-runner/_work/_tool/Python/3.12.11/x64/lib/python3.12/site-packages/mlperf_logging/rcp_checker/rcp_checker.py", line 93, in read_submission_file
    conv_epoch = json.loads(eval_accuracy_str)["metadata"]["epoch_num"]
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
```
Processing llama31_8b logs the same way as llama31_405b logs should solve the problem.