### PR TITLE
Fix SyntaxWarning from invalid escape sequences in regex patterns

### DIFF
--- a/mlperf_logging/compliance_checker/mlp_compliance.py
+++ b/mlperf_logging/compliance_checker/mlp_compliance.py
@@ -304,11 +304,11 @@ class ComplianceChecker:
 
 def usage_choices():
     return set(( x.split("_")[0] for x in os.listdir(os.path.dirname(__file__))
-             if re.match('\w+_\d+\.\d+\.\d+', x) ))
+             if re.match(r'\w+_\d+\.\d+\.\d+', x) ))
 
 def rule_choices():
     return set(( x.split("_")[1] for x in os.listdir(os.path.dirname(__file__))
-            if re.match('\w+_\d+\.\d+\.\d+', x) ))
+            if re.match(r'\w+_\d+\.\d+\.\d+', x) ))
 
 
 def get_parser():

--- a/mlperf_logging/compliance_checker/mlp_parser/ruleset_060.py
+++ b/mlperf_logging/compliance_checker/mlp_parser/ruleset_060.py
@@ -23,7 +23,7 @@ LogLine = collections.namedtuple('LogLine', [
 TOKEN = ':::MLL'
 
 # ^.*
-LINE_PATTERN = '^' + TOKEN + ''' [ ] # token and version
+LINE_PATTERN = '^' + TOKEN + r''' [ ] # token and version
 ([\d\.]+) [ ] # timestamp
 ([A-Za-z0-9_]+) [ ]? # key
 :\s+(.+) # value


### PR DESCRIPTION
Use raw strings for regex patterns in mlp_compliance.py and ruleset_060.py so that \w, \d, \s, and \. are not parsed as Python string escapes. The resulting strings are identical, so matching behavior is unchanged; this only silences the SyntaxWarning emitted by modern Python.