### PR TITLE
[MLPerf 6.1] Adding DLRMv4 MLPerf Logging Compliance Checker

### DIFF
--- a/mlperf_logging/benchmark_meta.py
+++ b/mlperf_logging/benchmark_meta.py
@@ -26,6 +26,7 @@ _ALL_RESULT_FILE_COUNTS = {
         'gpt_oss_20b': 10,
         'deepseekv3_671b': 3,
         'qwen35_397b_grpo': 3,
+        'dlrmv4': 10,
     },
     
     'hpc' : {
@@ -174,7 +175,8 @@ _ALL_ALLOWED_BENCHMARKS = {
         'llama2_70b_lora',
         'gpt_oss_20b',
         'deepseekv3_671b',
-        'qwen35_397b_grpo'
+        'qwen35_397b_grpo',
+        'dlrmv4'
     ]
     },
     

--- a/mlperf_logging/compliance_checker/README.md
+++ b/mlperf_logging/compliance_checker/README.md
@@ -39,6 +39,7 @@ As log examples use [NVIDIA's training logs](https://github.com/mlperf/training_
     6.0.0/open_llama2_70b_lora.yaml
     6.0.0/open_flux1.yaml
     6.0.0/open_gpt_oss_20b.yaml
+    6.1.0/open_dlrmv4.yaml
 
 ### Existing config files for HPC submissions
 

--- a/mlperf_logging/compliance_checker/README.md
+++ b/mlperf_logging/compliance_checker/README.md
@@ -32,6 +32,7 @@ As log examples use [NVIDIA's training logs](https://github.com/mlperf/training_
     6.0.0/closed_flux1.yaml
     6.0.0/closed_gpt_oss_20b.yaml
     6.1.0/closed_qwen35_397b_grpo.yaml
+    6.1.0/closed_dlrmv4.yaml
     6.0.0/open_llama31_8b.yaml
     6.0.0/open_llama31_405b.yaml
     6.0.0/open_dlrm_dcnv2.yaml

--- a/mlperf_logging/compliance_checker/training_6.1.0/closed_common.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/closed_common.yaml
@@ -2,7 +2,7 @@
 - KEY:
     NAME:  submission_benchmark
     REQ:   EXACTLY_ONE
-    CHECK: " v['value'] in ['flux1', 'llama31_8b', 'llama2_70b_lora', 'gpt_oss_20b', 'deepseekv3_671b', 'qwen35_397b_grpo'] "
+    CHECK: " v['value'] in ['flux1', 'llama31_8b', 'llama2_70b_lora', 'gpt_oss_20b', 'deepseekv3_671b', 'qwen35_397b_grpo', 'dlrmv4'] "
     POST:  " enqueue_config('training_6.1.0/closed_{}.yaml'.format(v['value'])) "
 
 - KEY:

--- a/mlperf_logging/compliance_checker/training_6.1.0/closed_dlrmv4.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/closed_dlrmv4.yaml
@@ -3,7 +3,7 @@
         s.update({
             'global_batch_size': None,
             'eval_interval_samples': None,
-            'skip_eval_epoch_pct': None,
+            'first_eval_samples': None,
             'opt_base_learning_rate': None,
             'train_samples': 2290835423,
             'target_accuracy': 0.75,
@@ -25,12 +25,16 @@
         s['eval_interval_samples'] = max(
             1, round(0.001 * (s['train_samples'] // v['value']))
         ) * v['value']
-        # Eval begins at the earliest observed convergence for this batch size,
-        # from the linear fit through the reference sweep, as a fraction of the
-        # epoch. The configured value is rounded, hence the tolerance below.
-        s['skip_eval_epoch_pct'] = (
-            math.floor((4480 * v['value'] + 135331840) / 3) / s['train_samples']
-        )
+        # Measurement must begin where the reference recipe begins it: at the
+        # earliest convergence observed for this batch size, from the linear fit
+        # through the reference sweep, less its two-block margin. That threshold
+        # is resolved against the eval grid, so the first eval lands on the
+        # first grid point at or after it -- block 25, 31 and 41 at global batch
+        # 8192, 16384 and 32768.
+        s['first_eval_samples'] = math.ceil(
+            math.floor((4480 * v['value'] + 135331840) / 3)
+            / s['eval_interval_samples']
+        ) * s['eval_interval_samples']
 
 - KEY:
     NAME:  gradient_accumulation_steps
@@ -123,15 +127,11 @@
     CHECK: " v['value'] == 0.001 "
 
 - KEY:
-    NAME:  skip_eval_epoch_pct
-    REQ:   EXACTLY_ONE
-    CHECK: " abs(v['value'] - s['skip_eval_epoch_pct']) < 1e-4 "
-
-- KEY:
     NAME:  eval_accuracy
     REQ:   AT_LEAST_ONE
     CHECK:
         - "'samples_count' in v['metadata']"
         - "v['metadata']['samples_count'] % s['eval_interval_samples'] == 0"
         - "0.0 <= v['value'] <= 1.0"
+    FIRST_CHECK: " int(v['metadata']['samples_count']) == s['first_eval_samples'] "
     ATLEAST_ONE_CHECK: "v['value'] >= s['target_accuracy']"

--- a/mlperf_logging/compliance_checker/training_6.1.0/closed_dlrmv4.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/closed_dlrmv4.yaml
@@ -1,0 +1,137 @@
+- BEGIN:
+    CODE: >
+        s.update({
+            'global_batch_size': None,
+            'eval_interval_samples': None,
+            'skip_eval_epoch_pct': None,
+            'opt_base_learning_rate': None,
+            'train_samples': 2290835423,
+            'target_accuracy': 0.75,
+        })
+
+# Only the target learning rate and the global batch size may be tuned; every
+# other hyperparameter below is fixed by the closed division.
+
+- KEY:
+    NAME:  global_batch_size
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] > 0 "
+    POST: |
+        s['global_batch_size'] = v['value']
+        # Eval fires whenever the global step crosses a multiple of
+        # round(eval_every_data_pct * total_train_steps), so convergence is
+        # reported on a fixed grid and is only comparable against the RCPs when
+        # the grid matches.
+        s['eval_interval_samples'] = max(
+            1, round(0.001 * (s['train_samples'] // v['value']))
+        ) * v['value']
+        # Eval begins at the earliest observed convergence for this batch size,
+        # from the linear fit through the reference sweep, as a fraction of the
+        # epoch. The configured value is rounded, hence the tolerance below.
+        s['skip_eval_epoch_pct'] = (
+            math.floor((4480 * v['value'] + 135331840) / 3) / s['train_samples']
+        )
+
+- KEY:
+    NAME:  gradient_accumulation_steps
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] > 0 "
+
+- KEY:
+    NAME:  train_samples
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == s['train_samples'] "
+
+- KEY:
+    NAME:  eval_samples
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 2058204 "
+
+- KEY:
+    NAME:  max_sequence_length
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 4096 "
+
+# Dense optimizer.
+
+- KEY:
+    NAME:  opt_name
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 'Adam' "
+
+- KEY:
+    NAME:  opt_base_learning_rate
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] > 0 "
+    POST:  " s['opt_base_learning_rate'] = v['value'] "
+
+- KEY:
+    NAME:  opt_adam_beta_1
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 0.95 "
+
+- KEY:
+    NAME:  opt_adam_beta_2
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 0.999 "
+
+- KEY:
+    NAME:  opt_adam_epsilon
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 1e-8 "
+
+- KEY:
+    NAME:  opt_weight_decay
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 0.0 "
+
+- KEY:
+    NAME:  opt_gradient_clip_norm
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 1.0 "
+
+# Sparse (embedding) optimizer. The single tunable learning rate applies to
+# both channels, which the reference ramps in lockstep.
+
+- KEY:
+    NAME:  opt_sparse_name
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 'RowWiseAdagrad' "
+
+- KEY:
+    NAME:  opt_sparse_base_learning_rate
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == s['opt_base_learning_rate'] "
+
+# Warmup: a linear ramp from zero to the target learning rate.
+
+- KEY:
+    NAME:  opt_learning_rate_warmup_steps
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 24000 "
+
+- KEY:
+    NAME:  opt_learning_rate_warmup_start_lr
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 0.0 "
+
+# Eval schedule.
+
+- KEY:
+    NAME:  eval_every_data_pct
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 0.001 "
+
+- KEY:
+    NAME:  skip_eval_epoch_pct
+    REQ:   EXACTLY_ONE
+    CHECK: " abs(v['value'] - s['skip_eval_epoch_pct']) < 1e-4 "
+
+- KEY:
+    NAME:  eval_accuracy
+    REQ:   AT_LEAST_ONE
+    CHECK:
+        - "'samples_count' in v['metadata']"
+        - "v['metadata']['samples_count'] % s['eval_interval_samples'] == 0"
+        - "0.0 <= v['value'] <= 1.0"
+    ATLEAST_ONE_CHECK: "v['value'] >= s['target_accuracy']"

--- a/mlperf_logging/compliance_checker/training_6.1.0/closed_dlrmv4.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/closed_dlrmv4.yaml
@@ -26,7 +26,7 @@
         # taken in sample space and divided ONCE by the global batch size,
         # rounding up, then scaled back to samples by the same batch size.
         s['eval_interval_samples'] = max(
-            1, math.ceil(0.001 * s['train_samples'] / v['value'])
+            1, int(math.ceil(0.001 * s['train_samples'] / v['value']))
         ) * v['value']
         # Measurement must begin where the reference recipe begins it: at the
         # earliest convergence observed for this batch size, from the linear fit
@@ -34,10 +34,10 @@
         # is resolved against the eval grid, so the first eval lands on the
         # first grid point at or after it -- block 25, 31 and 41 at global batch
         # 8192, 16384 and 32768.
-        s['first_eval_samples'] = math.ceil(
+        s['first_eval_samples'] = int(math.ceil(
             math.floor((4480 * v['value'] + 135331840) / 3)
             / s['eval_interval_samples']
-        ) * s['eval_interval_samples']
+        )) * s['eval_interval_samples']
 
 - KEY:
     NAME:  train_samples

--- a/mlperf_logging/compliance_checker/training_6.1.0/closed_dlrmv4.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/closed_dlrmv4.yaml
@@ -19,11 +19,14 @@
     POST: |
         s['global_batch_size'] = v['value']
         # Eval fires whenever the global step crosses a multiple of
-        # round(eval_every_data_pct * total_train_steps), so convergence is
-        # reported on a fixed grid and is only comparable against the RCPs when
-        # the grid matches.
+        # ceil(eval_every_data_pct * train_samples / global_batch_size), so
+        # convergence is reported on a fixed grid and is only comparable against
+        # the RCPs when the grid matches. This mirrors the reference's
+        # data_pct_to_global_steps() (mlcommons/training#889): the fraction is
+        # taken in sample space and divided ONCE by the global batch size,
+        # rounding up, then scaled back to samples by the same batch size.
         s['eval_interval_samples'] = max(
-            1, round(0.001 * (s['train_samples'] // v['value']))
+            1, math.ceil(0.001 * s['train_samples'] / v['value'])
         ) * v['value']
         # Measurement must begin where the reference recipe begins it: at the
         # earliest convergence observed for this batch size, from the linear fit
@@ -35,11 +38,6 @@
             math.floor((4480 * v['value'] + 135331840) / 3)
             / s['eval_interval_samples']
         ) * s['eval_interval_samples']
-
-- KEY:
-    NAME:  gradient_accumulation_steps
-    REQ:   EXACTLY_ONE
-    CHECK: " is_integer(v['value']) and v['value'] > 0 "
 
 - KEY:
     NAME:  train_samples

--- a/mlperf_logging/compliance_checker/training_6.1.0/open_common.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/open_common.yaml
@@ -2,5 +2,5 @@
 - KEY:
     NAME:  submission_benchmark
     REQ:   EXACTLY_ONE
-    CHECK: " v['value'] in ['flux1', 'llama31_8b', 'llama2_70b_lora', 'gpt_oss_20b', 'deepseekv3_671b', 'qwen35_397b_grpo'] "
+    CHECK: " v['value'] in ['flux1', 'llama31_8b', 'llama2_70b_lora', 'gpt_oss_20b', 'deepseekv3_671b', 'qwen35_397b_grpo', 'dlrmv4'] "
     POST:  " enqueue_config('training_6.1.0/open_{}.yaml'.format(v['value'])) "

--- a/mlperf_logging/compliance_checker/training_6.1.0/open_dlrmv4.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/open_dlrmv4.yaml
@@ -72,10 +72,6 @@
     REQ:   EXACTLY_ONE
 
 - KEY:
-    NAME:  skip_eval_epoch_pct
-    REQ:   EXACTLY_ONE
-
-- KEY:
     NAME:  eval_accuracy
     REQ:   AT_LEAST_ONE
     CHECK:

--- a/mlperf_logging/compliance_checker/training_6.1.0/open_dlrmv4.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/open_dlrmv4.yaml
@@ -1,0 +1,84 @@
+- KEY:
+    NAME:  global_batch_size
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] > 0 "
+
+- KEY:
+    NAME:  gradient_accumulation_steps
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] > 0 "
+
+- KEY:
+    NAME:  train_samples
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 2290835423 "
+
+- KEY:
+    NAME:  eval_samples
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] == 2058204 "
+
+- KEY:
+    NAME:  max_sequence_length
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] > 0 "
+
+- KEY:
+    NAME:  opt_name
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_base_learning_rate
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_adam_beta_1
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_adam_beta_2
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_adam_epsilon
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_weight_decay
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_gradient_clip_norm
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_sparse_name
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_sparse_base_learning_rate
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_learning_rate_warmup_steps
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  opt_learning_rate_warmup_start_lr
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  eval_every_data_pct
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  skip_eval_epoch_pct
+    REQ:   EXACTLY_ONE
+
+- KEY:
+    NAME:  eval_accuracy
+    REQ:   AT_LEAST_ONE
+    CHECK:
+        - "'samples_count' in v['metadata']"
+        - "0.0 <= v['value'] <= 1.0"
+    ATLEAST_ONE_CHECK: "v['value'] >= 0.75"

--- a/mlperf_logging/mllog/constants.py
+++ b/mlperf_logging/mllog/constants.py
@@ -59,6 +59,7 @@ LLAMA31_8B = "llama31_8b"
 FLUX1 = "flux1"
 DEEPSEEKV3_671B = "deepseekv3_671b"
 QWEN35_397B_GRPO = "qwen35_397b_grpo"
+DLRMV4 = "dlrmv4"
 
 # Constant values - model info
 ADAGRAD = "adagrad"
@@ -185,6 +186,11 @@ GENERATION_VALIDATION_ROLLOUT_TEMPERATURE = "generation_validation_rollout_tempe
 GENERATION_VALIDATION_ROLLOUT_TOP_P = "generation_validation_rollout_top_p"
 NUM_GENERATIONS_PER_PROMPT = "num_generations_per_prompt"
 NUM_PROMPTS_PER_STEP = "num_prompts_per_step"
+OPT_SPARSE_NAME = "opt_sparse_name"
+OPT_SPARSE_BASE_LR = "opt_sparse_base_learning_rate"
+OPT_LR_WARMUP_START_LR = "opt_learning_rate_warmup_start_lr"
+EVAL_EVERY_DATA_PCT = "eval_every_data_pct"
+SKIP_EVAL_EPOCH_PCT = "skip_eval_epoch_pct"
 # Log keys - misc.
 BBOX = "bbox"
 SEGM = "segm"

--- a/mlperf_logging/mllog/constants.py
+++ b/mlperf_logging/mllog/constants.py
@@ -190,7 +190,6 @@ OPT_SPARSE_NAME = "opt_sparse_name"
 OPT_SPARSE_BASE_LR = "opt_sparse_base_learning_rate"
 OPT_LR_WARMUP_START_LR = "opt_learning_rate_warmup_start_lr"
 EVAL_EVERY_DATA_PCT = "eval_every_data_pct"
-SKIP_EVAL_EPOCH_PCT = "skip_eval_epoch_pct"
 # Log keys - misc.
 BBOX = "bbox"
 SEGM = "segm"

--- a/mlperf_logging/rcp_checker/rcp_checker.py
+++ b/mlperf_logging/rcp_checker/rcp_checker.py
@@ -63,6 +63,7 @@ submission_runs = {
         'gpt_oss_20b': 10,
         'deepseekv3_671b': 3,
         'qwen35_397b_grpo': 3,
+        'dlrmv4': 10,
     },
     "hpc": {
         'cosmoflow': 10,
@@ -112,7 +113,7 @@ def read_submission_file(result_file, ruleset, use_train_samples):
                     eval_metric = json.loads(eval_accuracy_str)["metadata"]["metric"]
                     eval_score = json.loads(eval_accuracy_str)["value"]
                     stable_diffusion_eval_results[eval_step][eval_metric] = eval_score
-                elif benchmark in {"llama2_70b_lora", "flux1", "llama31_405b", "llama31_8b", "gpt_oss_20b", "deepseekv3_671b", "qwen35_397b_grpo"} and ("eval_error" in str or "eval_accuracy" in str):
+                elif benchmark in {"llama2_70b_lora", "flux1", "llama31_405b", "llama31_8b", "gpt_oss_20b", "deepseekv3_671b", "qwen35_397b_grpo", "dlrmv4"} and ("eval_error" in str or "eval_accuracy" in str):
                     eval_accuracy_str = str
                     conv_epoch = json.loads(eval_accuracy_str)["metadata"]["samples_count"]
                     eval_score = json.loads(eval_accuracy_str)["value"]

--- a/mlperf_logging/rcp_checker/training_6.1.0/rcps_dlrmv4.json
+++ b/mlperf_logging/rcp_checker/training_6.1.0/rcps_dlrmv4.json
@@ -1,0 +1,107 @@
+{
+  "dlrmv4_ref_8192": {
+    "Benchmark": "dlrmv4",
+    "Creator": "AMD",
+    "When": "Reference RCPs before 6.1 submission",
+    "Platform": "1x8xMI355X",
+    "Precision": "BF16",
+    "BS": 8192,
+    "Hyperparams": {
+      "opt_base_learning_rate": 1e-06,
+      "opt_learning_rate_warmup_steps": 24000,
+      "gradient_accumulation_steps": 1
+    },
+    "Epochs to converge": [
+      66519040,
+      68812800,
+      66519040,
+      66519040,
+      71106560,
+      80281600,
+      61931520,
+      68812800,
+      68812800,
+      73400320,
+      66519040,
+      73400320,
+      66519040,
+      66519040,
+      71106560,
+      73400320,
+      66519040,
+      71106560,
+      68812800,
+      68812800
+    ]
+  },
+  "dlrmv4_ref_16384": {
+    "Benchmark": "dlrmv4",
+    "Creator": "AMD",
+    "When": "Reference RCPs before 6.1 submission",
+    "Platform": "2x8xMI355X",
+    "Precision": "BF16",
+    "BS": 16384,
+    "Hyperparams": {
+      "opt_base_learning_rate": 2e-06,
+      "opt_learning_rate_warmup_steps": 24000,
+      "gradient_accumulation_steps": 1
+    },
+    "Epochs to converge": [
+      84869120,
+      84869120,
+      87162880,
+      91750400,
+      82575360,
+      82575360,
+      82575360,
+      91750400,
+      82575360,
+      82575360,
+      82575360,
+      77987840,
+      94044160,
+      96337920,
+      87162880,
+      89456640,
+      100925440,
+      98631680,
+      91750400,
+      82575360
+    ]
+  },
+  "dlrmv4_ref_32768": {
+    "Benchmark": "dlrmv4",
+    "Creator": "AMD",
+    "When": "Reference RCPs before 6.1 submission",
+    "Platform": "4x8xMI355X",
+    "Precision": "BF16",
+    "BS": 32768,
+    "Hyperparams": {
+      "opt_base_learning_rate": 4e-06,
+      "opt_learning_rate_warmup_steps": 24000,
+      "gradient_accumulation_steps": 1
+    },
+    "Epochs to converge": [
+      107806720,
+      105512960,
+      112394240,
+      105512960,
+      110100480,
+      107806720,
+      112394240,
+      123863040,
+      114688000,
+      110100480,
+      114688000,
+      128450560,
+      112394240,
+      112394240,
+      121569280,
+      98631680,
+      110100480,
+      128450560,
+      112394240,
+      110100480
+    ]
+  }
+}

--- a/mlperf_logging/rcp_checker/training_6.1.0/rcps_dlrmv4.json
+++ b/mlperf_logging/rcp_checker/training_6.1.0/rcps_dlrmv4.json
@@ -3,7 +3,7 @@
     "Benchmark": "dlrmv4",
     "Creator": "AMD",
     "When": "Reference RCPs before 6.1 submission",
-    "Platform": "1x8xMI355X",
+    "Platform": "1x8xMI350",
     "Precision": "BF16",
     "BS": 8192,
     "Hyperparams": {
@@ -38,7 +38,7 @@
     "Benchmark": "dlrmv4",
     "Creator": "AMD",
     "When": "Reference RCPs before 6.1 submission",
-    "Platform": "2x8xMI355X",
+    "Platform": "2x8xMI350",
     "Precision": "BF16",
     "BS": 16384,
     "Hyperparams": {
@@ -73,7 +73,7 @@
     "Benchmark": "dlrmv4",
     "Creator": "AMD",
     "When": "Reference RCPs before 6.1 submission",
-    "Platform": "4x8xMI355X",
+    "Platform": "4x8xMI350",
     "Precision": "BF16",
     "BS": 32768,
     "Hyperparams": {

--- a/mlperf_logging/result_summarizer/config.yaml
+++ b/mlperf_logging/result_summarizer/config.yaml
@@ -118,6 +118,7 @@ columns:
       gpt_oss_20b: ["Benchmark results (minutes)", "LLM", "C4", "GPT-OSS-20B"]
       deepseekv3_671b: ["Benchmark results (minutes)", "LLM", "C4", "DeepSeekV3-671B"]
       qwen35_397b_grpo: ["Benchmark results (minutes)", "LLM post training", "R2E-Gym-Subset (easy split)", "Qwen3.5-397B-A17B"]
+      dlrmv4: ["Benchmark results (minutes)", "Recommendation", "Yambda-5B", "DLRMv4 (HSTU)"]
       default: [" ", " ", " "]
 
   hpc:


### PR DESCRIPTION
## Summary

Registers `dlrmv4` as a Training 6.1 benchmark: closed and open rulesets, reference convergence points, log constants, and the result summarizer row. dlrmv4 is the HSTU recommendation benchmark on Yambda-5B, taking the recommendation slot that `dlrm_dcnv2` occupied through 6.0.

The three commits split cleanly if you'd prefer them reviewed separately: the closed ruleset and RCPs, then the constants and open ruleset, then the eval-start rule reworked to follow `deepseekv3_671b`.

## Changes

| File | Change |
|---|---|
| benchmark_meta.py | `'dlrmv4': 10` in training result counts; `'dlrmv4'` in the `'6.1'` allowed list |
| rcp_checker/rcp_checker.py | `'dlrmv4': 10` in submission_runs; dlrmv4 added to the samples_count allow-set in read_submission_file |
| rcp_checker/training_6.1.0/rcps_dlrmv4.json | New: three records at global batch 8192 / 16384 / 32768 |
| compliance_checker/training_6.1.0/closed_common.yaml | dlrmv4 appended to the submission_benchmark allow-list |
| compliance_checker/training_6.1.0/open_common.yaml | Same |
| compliance_checker/training_6.1.0/closed_dlrmv4.yaml | New closed ruleset |
| compliance_checker/training_6.1.0/open_dlrmv4.yaml | New open ruleset |
| compliance_checker/README.md | Lists both new yamls |
| mllog/constants.py | `DLRMV4` plus four log keys |
| result_summarizer/config.yaml | `dlrmv4: ["Benchmark results (minutes)", "Recommendation", "Yambda-5B", "DLRMv4 (HSTU)"]` |

## Convergence is keyed on `samples_count`

dlrmv4 converges at roughly 0.027 to 0.056 of an epoch. Rounding that to three decimals, as the `epoch_num` branch does, would collapse distinct seeds onto identical values, so dlrmv4 joins `llama31_8b`, `flux1`, `qwen35_397b_grpo` and the others in reading `metadata['samples_count']`.

## New log keys

Four keys have no existing constant. Three describe parts of the model no current benchmark has:

* `opt_sparse_name`, `opt_sparse_base_learning_rate` — the embedding-table optimizer, separate from the dense one.
* `opt_learning_rate_warmup_start_lr` — the absolute LR the ramp begins from, distinct from the existing warmup *step count*.

The fourth, `eval_every_data_pct`, describes the eval grid, which here is a correctness concern rather than bookkeeping, since samples-to-converge is quantized to it.

The remaining fixed hyperparameters map onto existing constants (`OPT_ADAM_BETA_1/2`, `OPT_ADAM_EPSILON`, `OPT_WEIGHT_DECAY`, `OPT_GRADIENT_CLIP_NORM`, `OPT_LR_WARMUP_STEPS`, `MAX_SEQUENCE_LENGTH`).

## What the closed rules pin

Only the **target learning rate** and the **global batch size** may be tuned. Everything else is fixed: optimizer names (`Adam` dense, `RowWiseAdagrad` sparse), Adam betas 0.95 / 0.999, epsilon 1e-8, weight decay 0, gradient clip norm 1.0, warmup of 24000 steps starting from LR 0, max sequence length 4096, and `train_samples` / `eval_samples`.

Two constraints are **computed from the logged global batch size** rather than hardcoded, because a single pinned value would be wrong at two of the three reference batch sizes:

* **`eval_interval_samples`** = `max(1, round(0.001 * (train_samples // GBS))) * GBS`. Convergence is reported on this grid, so samples-to-converge is quantized to it and is only comparable against the RCPs when the grid matches. Every `eval_accuracy` must land on it.
* **Where measurement starts.** The reference suppresses early eval passes until `floor((4480 * GBS + 135331840) / 3)` samples, a batch-size-dependent threshold that is easy to leave at the smallest batch size's default, silently shifting where measurement begins. Following the `deepseekv3_671b` pattern, this is enforced on the log rather than on a self-reported config value: a `FIRST_CHECK` on `eval_accuracy` requires the run's first eval to land on the grid point at or after that threshold — block 25, 31 and 41 at global batch 8192, 16384 and 32768. An earlier revision of this PR compared the logged `skip_eval_epoch_pct` against the formula instead, which a run could satisfy while still evaluating somewhere else; that key and its constant are now dropped.

The open ruleset keeps the task-defining constants and the AUC 0.75 target and drops the hyperparameter value checks, following the open/closed split used by `qwen35_397b_grpo` and `gpt_oss_20b`.

## RCP provenance

A 60-run sweep, 20 seeds at each of three batch sizes, on MI350X in BF16.

| BS | LR | earliest | mean | latest |
|---|---|---|---|---|
| 8192 | 1e-6 | 61.9M | 69.3M | 80.3M |
| 16384 | 2e-6 | 78.0M | 87.7M | 100.9M |
| 32768 | 4e-6 | 98.6M | 113.0M | 128.5M |

Each entry is the **first** eval reaching AUC 0.75, which is exactly what a compliant run reports, since the reference stops at the first crossing and emits `run_stop` with `status="success"`.

Note for reviewers: the reference sweep deliberately ran full convergence curves without early stopping, which is the normal way to generate RCPs, so those logs carry no `run_stop` and their eval grid starts at block 1 rather than at the skip threshold. The extraction rule above is stated explicitly so every number is reproducible from them.

## Validation

* Production-shaped compliant logs at **all three** batch sizes — built from real sweep seeds, filtered to the eval window a submission would produce (first eval at block 25 / 31 / 41, truncated at the first 0.75 crossing, `run_stop` appended) — pass the compliance checker with `--werror`, in both closed and open division.
* Six mutations are each rejected with the specific failing check: the wrong batch size's start point (a GBS-16384 run starting at block 25) and a start one block late both fail the new `FIRST_CHECK`; an eval one sample off the grid fails the divisibility check; and wrong Adam beta, a doubled eval cadence, and a sparse LR diverging from the dense one fail their respective checks.
* The eval-grid formula reproduces **all 4,779 eval events across all 60 reference logs with zero off-grid**, so the rule cannot reject a valid run.
* All edited YAML parses and all edited Python compiles; no duplicate constant names or key strings introduced.