### PR TITLE
Fix FLUX compliance for non power of 2 GBS

### DIFF
--- a/mlperf_logging/compliance_checker/training_6.1.0/closed_flux1.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/closed_flux1.yaml
@@ -2,11 +2,12 @@
     NAME:  global_batch_size
     REQ:   AT_LEAST_ONE
     CHECK: " v['value'] >= 0 "
+    POST: " s['eval_interval_samples'] = int(math.ceil(262144 / v['value'])) * v['value'] "
 
 - KEY:
     NAME:  evaluation_frequency
     REQ:   EXACTLY_ONE
-    CHECK: " v['value'] == 262144"
+    CHECK: " v['value'] == s['eval_interval_samples'] "
 
 - KEY:
     NAME:  opt_name


### PR DESCRIPTION
Flux rules (https://github.com/mlcommons/training_policies/blob/master/training_rules.adoc#94-quality-measure) say

```
Every 262144 training samples. CEIL(262144 / global_batch_size) * global_batch_size if 262144 is not divisible by GBS
```

which is not what the checker has been checking for