### PR TITLE
Make lowest precision, parallelism, MBS, and config_filename mandatory for v6.1

### DIFF
--- a/mlperf_logging/compliance_checker/training_6.1.0/common.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/common.yaml
@@ -144,42 +144,43 @@
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] != '' "
 
-# Optional keys
+# Mandatory precision and parallelism disclosure (v6.1+)
 - KEY:
     NAME:  lowest_numerical_precision_in_linear
-    REQ:   OPTIONAL
+    REQ:   EXACTLY_ONE
     CHECK: " v['value'] in ['fp64', 'fp32', 'tf32', 'fp16', 'fp8', 'nvfp4', 'mxfp4', 'bfloat16', 'Graphcore FLOAT 16.16', 'int8', 'uint8', 'int4', 'uint4'] "
 
 - KEY:
     NAME:  lowest_numerical_precision_in_attn
-    REQ:   OPTIONAL
+    REQ:   EXACTLY_ONE
     CHECK: " v['value'] in ['fp64', 'fp32', 'tf32', 'fp16', 'fp8', 'nvfp4', 'mxfp4', 'bfloat16', 'Graphcore FLOAT 16.16', 'int8', 'uint8', 'int4', 'uint4'] "
 
 - KEY:
     NAME:  lowest_numerical_precision_in_comm
-    REQ:   OPTIONAL
+    REQ:   EXACTLY_ONE
     CHECK: " v['value'] in ['fp64', 'fp32', 'tf32', 'fp16', 'fp8', 'nvfp4', 'mxfp4', 'bfloat16', 'Graphcore FLOAT 16.16', 'int8', 'uint8', 'int4', 'uint4'] "
 
 - KEY:
     NAME:  tensor_parallelism
-    REQ:   OPTIONAL
-    CHECK: " is_integer(v['value']) "
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] >= 1 "
 
 - KEY:
     NAME:  pipeline_parallelism
-    REQ:   OPTIONAL
-    CHECK: " is_integer(v['value']) "
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] >= 1 "
 
 - KEY:
     NAME:  context_parallelism
-    REQ:   OPTIONAL
-    CHECK: " is_integer(v['value']) "
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] >= 1 "
 
 - KEY:
     NAME:  expert_parallelism
-    REQ:   OPTIONAL
-    CHECK: " is_integer(v['value']) "
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] >= 1 "
 
+# Optional keys
 - KEY:
     NAME:  micro_batch_size
     REQ:   OPTIONAL

--- a/mlperf_logging/compliance_checker/training_6.1.0/common.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/common.yaml
@@ -144,7 +144,7 @@
     REQ:   EXACTLY_ONE
     CHECK: " v['value'] != '' "
 
-# Mandatory precision and parallelism disclosure (v6.1+)
+# Mandatory precision, parallelism, and run-config disclosure (v6.1+)
 - KEY:
     NAME:  lowest_numerical_precision_in_linear
     REQ:   EXACTLY_ONE
@@ -180,13 +180,13 @@
     REQ:   EXACTLY_ONE
     CHECK: " is_integer(v['value']) and v['value'] >= 1 "
 
-# Optional keys
 - KEY:
     NAME:  micro_batch_size
-    REQ:   OPTIONAL
-    CHECK: " is_integer(v['value']) "
+    REQ:   EXACTLY_ONE
+    CHECK: " is_integer(v['value']) and v['value'] >= 1 "
 
 - KEY:
     NAME:  config_filename
-    REQ:   OPTIONAL
+    REQ:   EXACTLY_ONE
+    CHECK: " v['value'] != '' "
 

--- a/mlperf_logging/mllog/constants.py
+++ b/mlperf_logging/mllog/constants.py
@@ -209,6 +209,11 @@ POWER_READING = "power_reading"
 CONVERTION_EFF = "conversion_eff"
 INTERCONNECT_POWER_EST = "interconnect_power_est"
 
+# Precision constants
+LOWEST_NUMERICAL_PRECISION_IN_ATTN = "lowest_numerical_precision_in_attn"
+LOWEST_NUMERICAL_PRECISION_IN_COMM = "lowest_numerical_precision_in_comm"
+LOWEST_NUMERICAL_PRECISION_IN_LINEAR = "lowest_numerical_precision_in_linear"
+
 # Parallelism constants
 TENSOR_PARALLELISM = "tensor_parallelism"
 PIPELINE_PARALLELISM = "pipeline_parallelism"

--- a/mlperf_logging/mllog/examples/parallelism.py
+++ b/mlperf_logging/mllog/examples/parallelism.py
@@ -33,7 +33,7 @@ def parallelism_example():
 
   mllogger.start(key=mllog.constants.RUN_START)
 
-  # Log the model config file used for this run
+  # Log the model config file used for this run. The name must match the submitted config.
   mllogger.event(key=mllog.constants.CONFIG_FILENAME, value="llama31_405b_config.yaml")
 
   # Log lowest numerical precision used in linear, attention, and communication

--- a/mlperf_logging/mllog/examples/parallelism.py
+++ b/mlperf_logging/mllog/examples/parallelism.py
@@ -19,7 +19,7 @@ from mlperf_logging import mllog
 
 
 def parallelism_example():
-  """Example usage of mllog with parallelism and config keys"""
+  """Example usage of mllog with mandatory precision, parallelism, and config keys"""
 
   mllogger = mllog.get_mllogger()
 
@@ -36,7 +36,12 @@ def parallelism_example():
   # Log the model config file used for this run
   mllogger.event(key=mllog.constants.CONFIG_FILENAME, value="llama31_405b_config.yaml")
 
-  # Log parallelism strategy
+  # Log lowest numerical precision used in linear, attention, and communication
+  mllogger.event(key=mllog.constants.LOWEST_NUMERICAL_PRECISION_IN_LINEAR, value="fp8")
+  mllogger.event(key=mllog.constants.LOWEST_NUMERICAL_PRECISION_IN_ATTN, value="bfloat16")
+  mllogger.event(key=mllog.constants.LOWEST_NUMERICAL_PRECISION_IN_COMM, value="fp8")
+
+  # Log parallelism strategy. Unused dimensions must still be logged as 1.
   mllogger.event(key=mllog.constants.TENSOR_PARALLELISM, value=8)
   mllogger.event(key=mllog.constants.PIPELINE_PARALLELISM, value=4)
   mllogger.event(key=mllog.constants.CONTEXT_PARALLELISM, value=2)


### PR DESCRIPTION
## Summary
- Make `lowest_numerical_precision_in_{linear,attn,comm}`, `{tensor,pipeline,context,expert}_parallelism`, `micro_batch_size`, and `config_filename` required (`EXACTLY_ONE`) in `training_6.1.0/common.yaml` so every Closed and Open result log must report them.
- Leave the v6.0 checker unchanged.
- Add mllog constants and update the parallelism example so submitters can log unused dimensions as `1`.

Fixes https://github.com/mlcommons/training/issues/878

Companion policy PR: https://github.com/mlcommons/training_policies/pull/592

## Test plan
- [x] Confirm `training_6.0.0/common.yaml` still marks these keys `OPTIONAL`
- [ ] Run the v6.1 compliance checker on a log missing any of the 9 keys and confirm it fails
- [ ] Run the v6.1 compliance checker on a log that reports all 9 keys with valid values, unused parallelism `= 1`, and a non-empty `config_filename` and confirm it passes these checks
- [ ] Confirm an invalid precision string, parallelism `< 1`, or `micro_batch_size < 1` fails the value `CHECK`