### PR TITLE
Update Qwen3.5 validation sample count

### DIFF
--- a/mlperf_logging/compliance_checker/training_6.1.0/closed_qwen35_397b_grpo.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/closed_qwen35_397b_grpo.yaml
@@ -26,7 +26,7 @@
 - KEY:
     NAME:  eval_samples
     REQ:   EXACTLY_ONE
-    CHECK: " v['value'] == 256 "
+    CHECK: " v['value'] == 251 "
 
 - KEY:
     NAME:  init_checkpoint_step

--- a/mlperf_logging/compliance_checker/training_6.1.0/open_qwen35_397b_grpo.yaml
+++ b/mlperf_logging/compliance_checker/training_6.1.0/open_qwen35_397b_grpo.yaml
@@ -11,7 +11,7 @@
 - KEY:
     NAME:  eval_samples
     REQ:   EXACTLY_ONE
-    CHECK: " v['value'] == 256 "
+    CHECK: " v['value'] == 251 "
 
 - KEY:
     NAME:  init_checkpoint_step


### PR DESCRIPTION
## Summary

- update the MLPerf Training v6.1 Qwen3.5 GRPO compliance rules for open and closed submissions
- require `eval_samples` to equal 251 instead of 256

## Rationale

Validation of the reference dataset removed five invalid validation tasks. The qualified validation dataset now contains 251 samples, so compliant benchmark logs report `eval_samples: 251`. The compliance checker must use the validated dataset size.

The corresponding dataset update is tracked in NVIDIA-NeMo/RL#3601.

## Verification

- parsed both updated YAML rule files with PyYAML
- verified both `eval_samples` checks require exactly 251
- ran `git diff --check`